### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,3 +267,34 @@ Follow these steps in order. Do not skip any step.
 - **Clippy is zero-tolerance**: CI runs clippy with all targets and features. Any warning fails the build. Always run `cargo clippy --all-targets --all-features` locally before pushing.
 
 - **Do not use `unsafe` beyond the existing PRNG seed**: The only `unsafe` in the codebase is in `transform.rs` for the global PRNG seed override (`RNG_SEED_OVERRIDE`). Do not add new `unsafe` blocks without a compelling reason and a code comment.
+
+---
+
+## Cursor Cloud specific instructions
+
+This is a pure Rust CLI project with **no external services** (no database, Docker, or network dependencies). The Rust stable toolchain (rustc + cargo) is the only prerequisite.
+
+### Quick reference
+
+| Task | Command |
+|------|---------|
+| Build | `cargo build` |
+| Test | `cargo test --all-targets --all-features` |
+| Lint | `cargo clippy --all-targets --all-features` |
+| Format check | `cargo fmt --all -- --check` |
+| Auto-format | `cargo fmt` |
+| Run CLI | `./target/debug/dumpling --help` |
+
+### Running the CLI
+
+Dumpling is fail-closed by default — it exits non-zero without a config file. To run a quick smoke test, either provide a `.dumplingconf` via `-c` or pass `--allow-noop`. Example:
+
+```bash
+./target/debug/dumpling --allow-noop -i /tmp/some_dump.sql -o /tmp/out.sql
+```
+
+### Notes
+
+- All 94 tests are inline `#[cfg(test)]` modules; there are no separate test files or fixtures to manage.
+- The update script uses `cargo fetch` to pre-download crate dependencies. A full `cargo build` or `cargo test` will then compile from the local cache without network access.
+- No environment variables or secrets are required for building, testing, or running the CLI locally.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with:

- Quick-reference table for build/test/lint/format/run commands
- Note on fail-closed default behavior and how to run quick smoke tests
- Clarification that no external services, env vars, or secrets are needed

**Update script**: `cargo fetch` (pre-downloads crate dependencies so subsequent builds compile from local cache).

**Verified locally**:
- `cargo fmt --all -- --check` — pass
- `cargo clippy --all-targets --all-features` — pass (zero warnings)
- `cargo test --all-targets --all-features` — 94/94 pass
- `cargo build` — success
- End-to-end anonymization demo — 5 rows processed, 20 cells anonymized

[demo_output.log](https://cursor.com/agents/bc-2c342a45-35fc-4b57-8bd0-1807bc834d4d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c342a45-35fc-4b57-8bd0-1807bc834d4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c342a45-35fc-4b57-8bd0-1807bc834d4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

