### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-02
+
 ### Added
 
 - **Env-backed secret references for config salts** (resolves [#11](https://github.com/ababic/dumpling/issues/11)): Salt fields in `.dumplingconf` / `pyproject.toml` now support `${ENV_VAR}` and `${env:ENV_VAR}` substitutions. Referencing a missing environment variable causes a non-zero startup failure with an actionable error message including the config-path and the variable name. Plaintext salts still work for backwards compatibility but emit a startup warning so accidental secret commits are visible in CI output.
@@ -27,3 +29,5 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - New CLI flags: `--scan-output` and `--fail-on-findings`.
 - Configurable output scan severities and per-category thresholds via `[output_scan]`.
 - JSON report section for output scan findings including category, count, threshold, severity, and sample locations.
+
+[0.2.0]: https://github.com/ababic/dumpling/compare/v0.1.0...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "dumpling"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dumpling"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "maturin"
 
 [project]
 name = "dumpling-cli"
+version = "0.2.0"
 description = "Static anonymizer for plain SQL dumps (PostgreSQL, SQLite, SQL Server)."
 readme = "README.md"
 requires-python = ">=3.8"
-dynamic = ["version"]
 keywords = ["postgres", "sqlite", "mssql", "sql", "anonymization", "cli", "rust"]
 classifiers = [
   "Development Status :: 4 - Beta",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prepares **v0.2.0** following the [release process](docs/src/releasing.md): bumps `Cargo.toml` / `Cargo.lock`, sets **`dumpling-cli` 0.2.0** in `pyproject.toml` (PyPI metadata), rolls the accumulated **[Unreleased]** changelog into **0.2.0** (dated 2026-05-02), and adds a compare link to GitHub.

This minor bump reflects additive functionality since `v0.1.0` (SQLite/MSSQL dialects, hardened security profile, env-backed salts, output scanning, CI/docs workflows, etc.).

## After merge

Maintainers should tag `main` and push to trigger release artifact builds:

```bash
git tag -a v0.2.0 -m "Release v0.2.0"
git push origin v0.2.0
```
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://wearecrew.slack.com/archives/D09256HV0AJ/p1777734410384829?thread_ts=1777734410.384829&cid=D09256HV0AJ)

<div><a href="https://cursor.com/agents/bc-13b7fc7a-923c-5732-997a-23a1d685676e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13b7fc7a-923c-5732-997a-23a1d685676e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

