### PR TITLE
feat: JSON path-level anonymisation in `[rules]`

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -184,6 +184,15 @@ Nested JSON targeting is supported in predicate `column` values via either:
 When a JSON path traverses an array, Dumpling checks each element (useful for
 list-of-dicts JSON structures).
 
+### JSON path rules (`json` / `jsonb` columns)
+
+You can anonymise values **inside** a text column that holds JSON using the same path syntax as row-filter predicates, but on **`[rules]` keys**:
+
+- Dot notation: `"payload.profile.email" = { strategy = "email", domain = "orders_email", as_string = true }`
+- Django-style: `"payload__profile__email" = { strategy = "hash", salt = "${env:ORDER_SECRET_SALT}", as_string = true }`
+
+The part before the first dot or `__` is the **SQL column name**; the rest is the path inside the parsed JSON document. Use **quoted** keys in TOML when the name contains dots. For a given table, you can use **either** path-level rules for a column **or** one whole-column rule for that column’s base name, not both (Dumpling rejects the conflict at startup). If a path is missing in a given row, that rule is skipped for that row. When only path rules apply (no whole-column rule), the rest of the JSON is left unchanged. Path rules are applied in **longest-path-first** order. `column_cases` still match the SQL column name only; use `when` predicates with nested `column` paths to branch on JSON content.
+
 ## Safety recommendations
 
 - Prefer deterministic runs in CI by passing `--seed` (or `DUMPLING_SEED`).
@@ -202,7 +211,7 @@ list-of-dicts JSON structures).
 - Sensitive columns are detected by:
   1. built-in column-name patterns, and
   2. explicit per-table lists under `[sensitive_columns]`.
-- A sensitive column is considered covered only if it has an explicit `rules` or `column_cases` entry.
+- A sensitive column is considered covered only if it has an explicit `rules` or `column_cases` entry (including JSON path rules whose base name is that column, e.g. `payload.x.y` covers `payload`).
 - If uncovered sensitive columns are found, Dumpling exits non-zero.
 
 When `--report` is enabled, coverage fields are added to JSON output:

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,4 +1,7 @@
-use crate::settings::{lookup_row_filters, Predicate, ResolvedConfig, When};
+use crate::settings::{
+    lookup_row_filters, parse_json_column_key, AnonymizerSpec, Predicate, ResolvedConfig, When,
+};
+use crate::transform::{apply_anonymizer, AnonymizerRegistry, Replacement};
 use regex::RegexBuilder;
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -127,51 +130,15 @@ fn extract_predicate_targets(
         return Some(vec![cells.get(i).cloned().unwrap_or(None)]);
     }
 
-    let (base_column, path) = parse_predicate_column_path(&pred.column)?;
+    let (base_column, path) = parse_json_column_key(&pred.column);
+    if path.is_empty() {
+        return None;
+    }
     let base_idx = columns
         .iter()
         .position(|c| c.eq_ignore_ascii_case(&base_column))?;
     let base_cell = cells.get(base_idx).and_then(|c| c.as_deref());
     Some(extract_json_path_targets(base_cell, &path))
-}
-
-fn parse_predicate_column_path(column: &str) -> Option<(String, Vec<String>)> {
-    let trim_parts = |parts: Vec<&str>| -> Option<(String, Vec<String>)> {
-        if parts.len() < 2 {
-            return None;
-        }
-        let base = parts[0].trim();
-        if base.is_empty() {
-            return None;
-        }
-        let path = parts[1..]
-            .iter()
-            .map(|p| p.trim())
-            .filter(|p| !p.is_empty())
-            .map(|p| p.to_string())
-            .collect::<Vec<_>>();
-        if path.is_empty() {
-            None
-        } else {
-            Some((base.to_string(), path))
-        }
-    };
-
-    if column.contains("__") {
-        let parts = column.split("__").collect::<Vec<_>>();
-        if let Some(parsed) = trim_parts(parts) {
-            return Some(parsed);
-        }
-    }
-
-    if column.contains('.') {
-        let parts = column.split('.').collect::<Vec<_>>();
-        if let Some(parsed) = trim_parts(parts) {
-            return Some(parsed);
-        }
-    }
-
-    None
 }
 
 fn extract_json_path_targets(cell: Option<&str>, path: &[String]) -> Vec<Option<String>> {
@@ -244,6 +211,113 @@ fn json_value_to_cell(v: serde_json::Value) -> Option<String> {
         serde_json::Value::Bool(b) => Some(if b { "true" } else { "false" }.to_string()),
         other => Some(other.to_string()),
     }
+}
+
+fn replacement_to_json_value(repl: &Replacement) -> serde_json::Value {
+    if repl.is_null {
+        return serde_json::Value::Null;
+    }
+    if repl.force_quoted {
+        return serde_json::Value::String(repl.value.clone());
+    }
+    serde_json::from_str(&repl.value)
+        .unwrap_or_else(|_| serde_json::Value::String(repl.value.clone()))
+}
+
+fn apply_leaf_replacement(target: &mut serde_json::Value, repl: &Replacement) {
+    *target = replacement_to_json_value(repl);
+}
+
+/// Mutate JSON document strings at configured paths using the same path semantics as predicates.
+pub fn rewrite_json_paths_with_rules(
+    registry: &AnonymizerRegistry,
+    column_max_len: Option<usize>,
+    json_rules: &[(Vec<String>, AnonymizerSpec)],
+    raw_json: &str,
+) -> anyhow::Result<String> {
+    let mut root = serde_json::from_str::<serde_json::Value>(raw_json)?;
+    for (path, spec) in json_rules {
+        let mut apply = |original_cell: Option<String>| {
+            apply_anonymizer(registry, spec, original_cell.as_deref(), column_max_len)
+        };
+        mutate_json_at_path(&mut root, path, &mut apply)?;
+    }
+    Ok(root.to_string())
+}
+
+fn mutate_json_at_path<F>(
+    value: &mut serde_json::Value,
+    segments: &[String],
+    apply: &mut F,
+) -> anyhow::Result<()>
+where
+    F: FnMut(Option<String>) -> Replacement,
+{
+    if segments.is_empty() {
+        return Ok(());
+    }
+    let seg = segments[0].as_str();
+    let rest = &segments[1..];
+
+    if rest.is_empty() {
+        match value {
+            serde_json::Value::Object(map) => {
+                if let Some(leaf) = map.get_mut(seg) {
+                    let original = json_value_to_cell(leaf.clone());
+                    let repl = apply(original);
+                    apply_leaf_replacement(leaf, &repl);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                if let Ok(idx) = seg.parse::<usize>() {
+                    if let Some(leaf) = items.get_mut(idx) {
+                        let original = json_value_to_cell(leaf.clone());
+                        let repl = apply(original);
+                        apply_leaf_replacement(leaf, &repl);
+                    }
+                } else {
+                    for item in items.iter_mut() {
+                        match item {
+                            serde_json::Value::Object(map) => {
+                                if let Some(leaf) = map.get_mut(seg) {
+                                    let original = json_value_to_cell(leaf.clone());
+                                    let repl = apply(original);
+                                    apply_leaf_replacement(leaf, &repl);
+                                }
+                            }
+                            serde_json::Value::Array(_) => {
+                                mutate_json_at_path(item, segments, apply)?;
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        return Ok(());
+    }
+
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(next) = map.get_mut(seg) {
+                mutate_json_at_path(next, rest, apply)?;
+            }
+        }
+        serde_json::Value::Array(items) => {
+            if let Ok(idx) = seg.parse::<usize>() {
+                if let Some(next) = items.get_mut(idx) {
+                    mutate_json_at_path(next, rest, apply)?;
+                }
+            } else {
+                for item in items.iter_mut() {
+                    mutate_json_at_path(item, rest, apply)?;
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 pub fn when_matches(when: &When, columns: &[String], cells: &[Option<String>]) -> bool {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -552,6 +552,7 @@ fn validate_raw_config(raw: &RawConfig) -> anyhow::Result<()> {
     }
 
     for (table_key, cols) in &raw.rules {
+        validate_rules_json_path_consistency(table_key, cols)?;
         for (col, spec) in cols {
             let base_path = format!("rules.\"{}\".{}", table_key, col);
             validate_anonymizer_spec(spec, &base_path)?;
@@ -784,7 +785,131 @@ fn validate_anonymizer_spec(spec: &AnonymizerSpec, path: &str) -> anyhow::Result
     Ok(())
 }
 
+/// Split a rules column key into the SQL column name and optional JSON path segments.
+///
+/// Nested paths use the same syntax as row-filter predicates: `payload.profile.email` or
+/// `payload__profile__email`. When no path is present, the entire key names one SQL column.
+/// Keys are compared case-insensitively after normalization (lowercase).
+pub fn parse_json_column_key(column_key: &str) -> (String, Vec<String>) {
+    let trim_parts = |parts: &[&str]| -> Option<(String, Vec<String>)> {
+        if parts.len() < 2 {
+            return None;
+        }
+        let base = parts[0].trim();
+        if base.is_empty() {
+            return None;
+        }
+        let path = parts[1..]
+            .iter()
+            .map(|p| p.trim())
+            .filter(|p| !p.is_empty())
+            .map(|p| p.to_string())
+            .collect::<Vec<_>>();
+        if path.is_empty() {
+            None
+        } else {
+            Some((base.to_string(), path))
+        }
+    };
+
+    let lower_full = column_key.to_lowercase();
+
+    if column_key.contains("__") {
+        let parts = column_key.split("__").collect::<Vec<_>>();
+        if let Some((base, path)) = trim_parts(&parts) {
+            return (base.to_lowercase(), path);
+        }
+    }
+
+    if column_key.contains('.') {
+        let parts = column_key.split('.').collect::<Vec<_>>();
+        if let Some((base, path)) = trim_parts(&parts) {
+            return (base.to_lowercase(), path);
+        }
+    }
+
+    (lower_full, Vec::new())
+}
+
+fn validate_rules_json_path_consistency(
+    table_key: &str,
+    cols: &HashMap<String, AnonymizerSpec>,
+) -> anyhow::Result<()> {
+    let normalized_keys: HashSet<String> = cols.keys().map(|k| k.to_lowercase()).collect();
+    for col_key in &normalized_keys {
+        let (base, path) = parse_json_column_key(col_key);
+        if path.is_empty() {
+            continue;
+        }
+        if normalized_keys.contains(&base) {
+            anyhow::bail!(
+                "rules table \"{}\" has conflicting keys: nested path \"{}\" cannot be combined with a whole-column rule on \"{}\"",
+                table_key,
+                col_key,
+                base
+            );
+        }
+    }
+    Ok(())
+}
+
+/// JSON path-level rules for one logical SQL column: `(path_segments, spec)` sorted with
+/// longest paths first so nested targets are handled before broader paths.
+pub fn lookup_json_path_rules_for_column<'a>(
+    cfg: &'a ResolvedConfig,
+    schema: Option<&str>,
+    table: &str,
+    column: &str,
+) -> Vec<(Vec<String>, &'a AnonymizerSpec)> {
+    let column_norm = column.to_lowercase();
+    let mut by_path: HashMap<Vec<String>, &'a AnonymizerSpec> = HashMap::new();
+
+    let mut collect = |cols: &'a HashMap<String, AnonymizerSpec>| {
+        for (key, spec) in cols {
+            let (base, path) = parse_json_column_key(key);
+            if base == column_norm && !path.is_empty() {
+                by_path.entry(path).or_insert(spec);
+            }
+        }
+    };
+
+    if let Some(s) = schema {
+        let key = format!("{}.{}", s.to_lowercase(), table.to_lowercase());
+        if let Some(cols) = cfg.rules.get(&key) {
+            collect(cols);
+        }
+    }
+    let key = table.to_lowercase();
+    if let Some(cols) = cfg.rules.get(&key) {
+        collect(cols);
+    }
+
+    let mut out: Vec<(Vec<String>, &'a AnonymizerSpec)> = by_path.into_iter().collect();
+    out.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+    out
+}
+
+fn lookup_whole_column_rule_in_map<'a>(
+    cols: &'a HashMap<String, AnonymizerSpec>,
+    column_norm: &str,
+) -> Option<&'a AnonymizerSpec> {
+    if let Some(spec) = cols.get(column_norm) {
+        let (_, path) = parse_json_column_key(column_norm);
+        if path.is_empty() {
+            return Some(spec);
+        }
+    }
+    for (k, spec) in cols {
+        let (base, path) = parse_json_column_key(k);
+        if base == column_norm && path.is_empty() {
+            return Some(spec);
+        }
+    }
+    None
+}
+
 /// Helper to lookup a column rule by table identifiers. Tries schema-qualified then unqualified.
+/// Keys that include a JSON path (`payload.field`) are excluded; use `lookup_json_path_rules_for_column`.
 pub fn lookup_column_rule<'a>(
     cfg: &'a ResolvedConfig,
     schema: Option<&str>,
@@ -792,23 +917,18 @@ pub fn lookup_column_rule<'a>(
     column: &str,
 ) -> Option<&'a AnonymizerSpec> {
     let column_norm = column.to_lowercase();
-    // Try schema.table if schema provided
     if let Some(s) = schema {
         let key = format!("{}.{}", s.to_lowercase(), table.to_lowercase());
         if let Some(cols) = cfg.rules.get(&key) {
-            if let Some(spec) = cols.get(&column_norm) {
+            if let Some(spec) = lookup_whole_column_rule_in_map(cols, &column_norm) {
                 return Some(spec);
             }
         }
     }
-    // Try unqualified table
     let key = table.to_lowercase();
-    if let Some(cols) = cfg.rules.get(&key) {
-        if let Some(spec) = cols.get(&column_norm) {
-            return Some(spec);
-        }
-    }
-    None
+    cfg.rules
+        .get(&key)
+        .and_then(|cols| lookup_whole_column_rule_in_map(cols, &column_norm))
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1150,6 +1270,27 @@ age = { strategy = "int_range", min = 100, max = 10 }
         let msg = format!("{:#}", err);
         assert!(msg.contains("rules.\"public.users\".age"));
         assert!(msg.contains("min (100) must be <= max (10)"));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn conflicting_json_path_and_whole_column_rules_fail_validation() {
+        let path = write_temp_config(
+            r#"
+salt = "testsalt"
+[rules."public.orders"]
+"payload" = { strategy = "redact", as_string = true }
+"payload__buyer__email" = { strategy = "email", domain = "buyer_emails" }
+"#,
+        );
+        let err =
+            load_config(Some(&path), false).expect_err("expected semantic validation failure");
+        let msg = format!("{:#}", err);
+        assert!(
+            msg.contains("conflicting keys") && msg.contains("nested path"),
+            "{}",
+            msg
+        );
         let _ = fs::remove_file(path);
     }
 

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1,8 +1,8 @@
-use crate::filter::{should_keep_row, when_matches};
+use crate::filter::{rewrite_json_paths_with_rules, should_keep_row, when_matches};
 use crate::report::Reporter;
 use crate::settings::{
-    is_explicit_sensitive_column, lookup_column_cases, lookup_column_rule, AnonymizerSpec,
-    ResolvedConfig,
+    is_explicit_sensitive_column, lookup_column_cases, lookup_column_rule,
+    lookup_json_path_rules_for_column, AnonymizerSpec, ResolvedConfig,
 };
 use crate::transform::{apply_anonymizer, AnonymizerRegistry, Replacement};
 use anyhow::Context;
@@ -256,54 +256,53 @@ impl SqlStreamProcessor {
                         let mut new_fields: Vec<String> = Vec::with_capacity(fields.len());
                         for (idx, field) in fields.iter().enumerate() {
                             let col = columns.get(idx).map(|s| s.as_str()).unwrap_or_else(|| "");
-                            let selected = select_strategy_for_cell(
-                                &self.config,
+                            let original = if *field == r"\N" { None } else { Some(*field) };
+                            match self.apply_column_rules(
                                 schema.as_deref(),
                                 table,
                                 columns,
                                 &unescaped,
                                 col,
-                            );
-                            // \N is null
-                            let original = if *field == r"\N" { None } else { Some(*field) };
-                            if let Some(spec) = selected {
-                                let col_len =
-                                    self.lookup_column_max_length(schema.as_deref(), table, col);
-                                let repl =
-                                    apply_anonymizer(&self.anonymizers, &spec, original, col_len);
-                                if let Some(rp) = self.reporter.as_ref() {
-                                    unsafe {
-                                        (*(*rp)).record_cell_changed(
-                                            schema.as_deref(),
-                                            table,
-                                            col,
-                                            &spec.strategy,
-                                            original.is_none(),
-                                        );
-                                        if let Some(domain) = spec
-                                            .domain
-                                            .as_deref()
-                                            .map(str::trim)
-                                            .filter(|value| !value.is_empty())
-                                        {
-                                            (*(*rp)).record_deterministic_mapping_domain(
-                                                schema.as_deref(),
-                                                table,
-                                                col,
-                                                domain,
-                                                spec.unique_within_domain.unwrap_or(false),
-                                            );
+                                original,
+                            ) {
+                                Ok(None) => {
+                                    new_fields.push((*field).to_string());
+                                }
+                                Ok(Some((repl, specs))) => {
+                                    for spec in &specs {
+                                        if let Some(rp) = self.reporter.as_ref() {
+                                            unsafe {
+                                                (*(*rp)).record_cell_changed(
+                                                    schema.as_deref(),
+                                                    table,
+                                                    col,
+                                                    &spec.strategy,
+                                                    original.is_none(),
+                                                );
+                                                if let Some(domain) = spec
+                                                    .domain
+                                                    .as_deref()
+                                                    .map(str::trim)
+                                                    .filter(|value| !value.is_empty())
+                                                {
+                                                    (*(*rp)).record_deterministic_mapping_domain(
+                                                        schema.as_deref(),
+                                                        table,
+                                                        col,
+                                                        domain,
+                                                        spec.unique_within_domain.unwrap_or(false),
+                                                    );
+                                                }
+                                            }
                                         }
                                     }
+                                    if repl.is_null {
+                                        new_fields.push(r"\N".to_string());
+                                    } else {
+                                        new_fields.push(repl.value);
+                                    }
                                 }
-                                if repl.is_null {
-                                    new_fields.push(r"\N".to_string());
-                                } else {
-                                    // In COPY, write raw with tabs avoided; our anonymizers generate safe content.
-                                    new_fields.push(repl.value);
-                                }
-                            } else {
-                                new_fields.push((*field).to_string());
+                                Err(e) => return Err(e),
                             }
                         }
                         // Re-add trailing newline
@@ -425,50 +424,48 @@ impl SqlStreamProcessor {
             let mut rendered_cells: Vec<String> = Vec::with_capacity(row.len());
             for (i, cell) in row.into_iter().enumerate() {
                 let col = columns.get(i).map(|s| s.as_str()).unwrap_or("");
-                let selected = select_strategy_for_cell(
-                    &self.config,
+                match self.apply_column_rules(
                     schema.as_deref(),
                     &table,
                     &columns,
                     &cell_values,
                     col,
-                );
-                if let Some(spec) = selected {
-                    let col_len = self.lookup_column_max_length(schema.as_deref(), &table, col);
-                    let replacement = apply_anonymizer(
-                        &self.anonymizers,
-                        &spec,
-                        cell.original.as_deref(),
-                        col_len,
-                    );
-                    if let Some(rp) = self.reporter {
-                        unsafe {
-                            (*rp).record_cell_changed(
-                                schema.as_deref(),
-                                &table,
-                                col,
-                                &spec.strategy,
-                                cell.original.is_none(),
-                            );
-                            if let Some(domain) = spec
-                                .domain
-                                .as_deref()
-                                .map(str::trim)
-                                .filter(|value| !value.is_empty())
-                            {
-                                (*rp).record_deterministic_mapping_domain(
-                                    schema.as_deref(),
-                                    &table,
-                                    col,
-                                    domain,
-                                    spec.unique_within_domain.unwrap_or(false),
-                                );
+                    cell.original.as_deref(),
+                ) {
+                    Ok(None) => {
+                        rendered_cells.push(cell.render_original());
+                    }
+                    Ok(Some((replacement, specs))) => {
+                        for spec in &specs {
+                            if let Some(rp) = self.reporter {
+                                unsafe {
+                                    (*rp).record_cell_changed(
+                                        schema.as_deref(),
+                                        &table,
+                                        col,
+                                        &spec.strategy,
+                                        cell.original.is_none(),
+                                    );
+                                    if let Some(domain) = spec
+                                        .domain
+                                        .as_deref()
+                                        .map(str::trim)
+                                        .filter(|value| !value.is_empty())
+                                    {
+                                        (*rp).record_deterministic_mapping_domain(
+                                            schema.as_deref(),
+                                            &table,
+                                            col,
+                                            domain,
+                                            spec.unique_within_domain.unwrap_or(false),
+                                        );
+                                    }
+                                }
                             }
                         }
+                        rendered_cells.push(render_cell(&replacement, &cell));
                     }
-                    rendered_cells.push(render_cell(&replacement, &cell));
-                } else {
-                    rendered_cells.push(cell.render_original());
+                    Err(e) => return Err(e),
                 }
             }
             out.push('(');
@@ -531,6 +528,43 @@ impl SqlStreamProcessor {
         self.column_length_limits
             .get(&table_key)
             .and_then(|cols| cols.get(&column_key).copied())
+    }
+
+    /// Applies whole-column and/or JSON path rules. Returns `None` to passthrough the original cell.
+    fn apply_column_rules(
+        &self,
+        schema: Option<&str>,
+        table: &str,
+        columns: &[String],
+        row_cells: &[Option<String>],
+        col: &str,
+        cell_original: Option<&str>,
+    ) -> anyhow::Result<Option<(Replacement, Vec<AnonymizerSpec>)>> {
+        let selected =
+            select_strategy_for_cell(&self.config, schema, table, columns, row_cells, col);
+        let json_refs = lookup_json_path_rules_for_column(&self.config, schema, table, col);
+        let json_owned: Vec<(Vec<String>, AnonymizerSpec)> =
+            json_refs.into_iter().map(|(p, s)| (p, s.clone())).collect();
+
+        if selected.is_none() && json_owned.is_empty() {
+            return Ok(None);
+        }
+
+        let col_len = self.lookup_column_max_length(schema, table, col);
+
+        if let Some(spec) = selected {
+            let repl = apply_anonymizer(&self.anonymizers, &spec, cell_original, col_len);
+            return Ok(Some((repl, vec![spec])));
+        }
+
+        let raw = match cell_original {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+        let specs: Vec<AnonymizerSpec> = json_owned.iter().map(|(_, s)| s.clone()).collect();
+        let out = rewrite_json_paths_with_rules(&self.anonymizers, col_len, &json_owned, raw)?;
+        let repl = Replacement::quoted(out);
+        Ok(Some((repl, specs)))
     }
 
     fn track_sensitive_coverage(&mut self, schema: Option<&str>, table: &str, columns: &[String]) {
@@ -1353,6 +1387,7 @@ fn is_explicitly_covered_column(
         || lookup_column_cases(cfg, schema, table, column)
             .map(|cases| !cases.is_empty())
             .unwrap_or(false)
+        || !lookup_json_path_rules_for_column(cfg, schema, table, column).is_empty()
 }
 
 fn qualified_column_name(schema: Option<&str>, table: &str, column: &str) -> String {
@@ -2211,6 +2246,84 @@ COPY public.events (id, payload) FROM stdin;
         assert!(!s.contains(
             "\n6\t{\"profile\":{\"tier\":\"silver\"},\"events\":[{\"kind\":\"keep\"}]}\n"
         ));
+    }
+
+    #[test]
+    fn pipeline_anonymizes_nested_json_paths_for_insert_and_copy() {
+        let mut rules: HashMap<String, HashMap<String, AnonymizerSpec>> = HashMap::new();
+        let mut cols: HashMap<String, AnonymizerSpec> = HashMap::new();
+        cols.insert(
+            "payload.profile.secret".to_string(),
+            AnonymizerSpec {
+                strategy: "string".to_string(),
+                salt: None,
+                min: None,
+                max: None,
+                length: Some(8),
+                min_days: None,
+                max_days: None,
+                min_seconds: None,
+                max_seconds: None,
+                domain: Some("secrets".to_string()),
+                unique_within_domain: None,
+                as_string: Some(true),
+                locale: None,
+            },
+        );
+        rules.insert("public.events".to_string(), cols);
+        let cfg = ResolvedConfig {
+            salt: None,
+            rules,
+            row_filters: HashMap::new(),
+            column_cases: HashMap::new(),
+            sensitive_columns: HashMap::new(),
+            output_scan: crate::settings::OutputScanConfig::default(),
+            source_path: None,
+        };
+        let reg = AnonymizerRegistry::from_config(&cfg);
+        let mut proc =
+            SqlStreamProcessor::new(reg, cfg, Vec::new(), Vec::new(), None, DumpFormat::Postgres);
+        let input = r#"
+CREATE TABLE public.events (id int, payload jsonb);
+INSERT INTO public.events (id, payload) VALUES
+  (1, '{"profile":{"tier":"gold","secret":"alpha"}}');
+
+COPY public.events (id, payload) FROM stdin;
+2	{"profile":{"tier":"gold","secret":"alpha"}}
+\.
+"#;
+        let mut reader = std::io::BufReader::new(input.as_bytes());
+        let mut out = Vec::new();
+        proc.process(&mut reader, &mut out).unwrap();
+        let s = String::from_utf8(out).unwrap();
+        assert!(
+            s.contains("\"tier\":\"gold\""),
+            "non-target JSON fields should be preserved, got:\n{s}"
+        );
+        assert!(
+            !s.contains("alpha"),
+            "nested secret should be anonymized, got:\n{s}"
+        );
+        let insert_pos = s.find("INSERT INTO public.events").unwrap();
+        let insert_tail = &s[insert_pos..];
+        let insert_end = insert_tail.find(";\n").unwrap() + insert_pos;
+        let ins_stmt = &s[insert_pos..=insert_end];
+        let vals_idx = ins_stmt.to_uppercase().find("VALUES").unwrap();
+        let ins_block = strip_trailing_semicolon(ins_stmt[vals_idx + "VALUES".len()..].trim());
+        let ins_rows = parse_values_rows(ins_block).unwrap();
+        let copy_line = s
+            .lines()
+            .find(|l| l.starts_with("2\t{"))
+            .expect("expected COPY data row");
+        let copy_json = copy_line.split_once('\t').unwrap().1;
+        let v_ins =
+            serde_json::from_str::<serde_json::Value>(ins_rows[0][1].original.as_ref().unwrap())
+                .unwrap();
+        let v_copy = serde_json::from_str::<serde_json::Value>(copy_json).unwrap();
+        assert_eq!(
+            v_ins["profile"]["secret"], v_copy["profile"]["secret"],
+            "INSERT and COPY must apply the same nested anonymization"
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #37.

### Summary

Adds optional **nested JSON path targets** under `[rules]` using the same syntax as row-filter predicates (`payload.profile.email` or `payload__profile__email`). The anonymiser parses the SQL column value as JSON, rewrites only the targeted paths in place, and serialises back—preserving structure and non-sensitive fields.

### Behaviour

- **Whole-column rules** still use a plain column key (e.g. `payload = { ... }`).
- **Path rules** use quoted TOML keys when needed (e.g. `"payload.buyer.email" = { ... }`).
- **Conflict**: defining both a whole-column rule on `payload` and path rules under `payload.*` for the same table is rejected at config validation with a clear error.
- **Multiple paths**: longest path first; applies each strategy with the existing `apply_anonymizer` pipeline (deterministic `domain`, truncation for column length, etc.).
- **Strict coverage**: a path rule whose base matches a SQL column counts as covering that column for `--strict-coverage`.
- **column_cases**: unchanged—`when` still matches SQL column names; use nested predicate columns inside `when` for JSON-aware branching.

### Docs

`docs/src/configuration.md` documents JSON path rules and updates the strict-coverage bullet.

### Tests

- Pipeline test for INSERT + COPY nested rewrite with deterministic `string` + `domain`.
- Config validation test for conflicting whole-column + path keys.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://wearecrew.slack.com/archives/D09256HV0AJ/p1777737493209159?thread_ts=1777737493.209159&cid=D09256HV0AJ)

<div><a href="https://cursor.com/agents/bc-0a43de6d-c949-5142-a0ef-32f73da33df1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a43de6d-c949-5142-a0ef-32f73da33df1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

