### PR TITLE
docs: Custom-format pg_dump → plain SQL before Dumpling

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,17 @@ Produced by `pg_dump --format=plain`. Handles:
 
 Binary, custom, and directory formats from `pg_dump` are not supported — use `--format=plain` when running `pg_dump`.
 
+**Smaller transfers, plain SQL locally.** Custom format (`pg_dump -Fc`, the default when you omit `--format`) compresses well and is often used to save bandwidth. You cannot feed that file to Dumpling directly; decode it to plain SQL on the machine where you run Dumpling, using the same PostgreSQL client tools as `pg_restore`.
+
+1. Copy the archive to your workstation (e.g. `backup.dump` or a directory-format folder from `pg_dump -Fd`).
+2. Convert to plain SQL with `pg_restore` (script mode, no database required):
+   - Write a file: `pg_restore -f sanitized_input.sql backup.dump`
+   - Or stream to Dumpling without an intermediate file (Dumpling reads plain SQL from **stdin** when you omit `--input`):  
+     `pg_restore -f - backup.dump | dumpling -o sanitized.sql`
+3. If you wrote a file in step 2, run Dumpling on it: `dumpling -i sanitized_input.sql -o sanitized.sql`
+
+For directory-format dumps, pass the directory path instead of a single file: `pg_restore -f - /path/to/backup_dir | dumpling ...`. You need `pg_restore` from a PostgreSQL client install version-compatible with the archive (same major version as the source server is safest).
+
 ### SQLite (`--format sqlite`)
 
 Produced by the SQLite CLI `.dump` command or equivalent. Handles:

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -17,6 +17,14 @@ dumpling --format sqlite -i data.db.sql -o anonymized.sql
 dumpling --format mssql  -i backup.sql  -o anonymized.sql
 ```
 
+Dumpling only accepts **plain SQL**. If you transferred a smaller **custom-format** (`pg_dump -Fc`) or **directory-format** archive for bandwidth, decode it locally with `pg_restore` (no database needed in script mode), then run Dumpling on the result or pipe plain SQL on stdin:
+
+```bash
+pg_restore -f - backup.dump | dumpling -o anonymized.sql
+```
+
+Use a PostgreSQL client whose `pg_restore` version matches the dump (same major version as the source server is safest).
+
 ---
 
 ## Configuration sources


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the workflow for teams that transfer **PostgreSQL custom-format** (`pg_dump -Fc`) or **directory-format** dumps for bandwidth, then need **plain SQL** for Dumpling.

## Changes

- **README** (`## Input format` → PostgreSQL): Adds a short subsection with numbered steps: copy archive locally, run `pg_restore -f` (file or stdout), run Dumpling on the result or pipe plain SQL into Dumpling via stdin (omit `--input`). Notes directory dumps and version compatibility for `pg_restore`.
- **docs** (`configuration.md`): Adds the same pipe example after the `--format` examples so mdBook readers see it next to dialect selection.

No code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://wearecrew.slack.com/archives/D09256HV0AJ/p1777745555955349?thread_ts=1777745555.955349&cid=D09256HV0AJ)

<div><a href="https://cursor.com/agents/bc-080bab9c-55f1-5aa0-a05c-4c2ab747d159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-080bab9c-55f1-5aa0-a05c-4c2ab747d159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

