### PR TITLE
feat: --dump-decode for pg_restore-backed PostgreSQL archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,16 @@ Produced by `pg_dump --format=plain`. Handles:
 - `"double-quoted"` identifiers
 - `''`-escaped string literals
 
-Binary, custom, and directory formats from `pg_dump` are not supported — use `--format=plain` when running `pg_dump`.
+Binary, custom, and directory formats from `pg_dump` are not parsed directly — Dumpling’s SQL pipeline expects plain text. Use either:
+
+- **`pg_dump --format=plain`** when you control capture, or
+- **`dumpling --dump-decode`** with `--input` set to a **custom-format** (`.dump`) or **directory-format** folder: Dumpling runs `pg_restore -f -` and streams the resulting SQL (same as a manual `pg_restore` “script” output, no database required). Requires PostgreSQL client tools on `PATH` (`pg_restore`), or set `--pg-restore-path`. Use `--dump-decode-arg` to pass extra flags (e.g. `--no-owner --no-acl`). With `--dump-decode-delete-input`, the archive is removed only after a fully successful run (and is disallowed with `--check`).
+
+Example (e.g. after `heroku pg:backups:download`):
+
+```bash
+dumpling --dump-decode --dump-decode-delete-input -i latest.dump -c .dumplingconf -o anonymized.sql
+```
 
 ### SQLite (`--format sqlite`)
 

--- a/README.md
+++ b/README.md
@@ -271,12 +271,12 @@ Produced by `pg_dump --format=plain`. Handles:
 Binary, custom, and directory formats from `pg_dump` are not parsed directly — Dumpling’s SQL pipeline expects plain text. Use either:
 
 - **`pg_dump --format=plain`** when you control capture, or
-- **`dumpling --dump-decode`** with `--input` set to a **custom-format** (`.dump`) or **directory-format** folder: Dumpling runs `pg_restore -f -` and streams the resulting SQL (same as a manual `pg_restore` “script” output, no database required). Requires PostgreSQL client tools on `PATH` (`pg_restore`), or set `--pg-restore-path`. Use `--dump-decode-arg` to pass extra flags (e.g. `--no-owner --no-acl`). With `--dump-decode-delete-input`, the archive is removed only after a fully successful run (and is disallowed with `--check`).
+- **`dumpling --dump-decode`** with `--input` set to a **custom-format** (`.dump`) or **directory-format** folder: Dumpling runs `pg_restore -f -` and streams the resulting SQL (same as a manual `pg_restore` “script” output, no database required). Requires PostgreSQL client tools on `PATH` (`pg_restore`), or set `--pg-restore-path`. Use `--dump-decode-arg` to pass extra flags (e.g. `--no-owner --no-acl`). **By default** the archive is removed after a fully successful run; pass **`--dump-decode-keep-input`** to retain it. **`--check`** requires **`--dump-decode-keep-input`** so the archive still exists if changes would be detected.
 
 Example (e.g. after `heroku pg:backups:download`):
 
 ```bash
-dumpling --dump-decode --dump-decode-delete-input -i latest.dump -c .dumplingconf -o anonymized.sql
+dumpling --dump-decode -i latest.dump -c .dumplingconf -o anonymized.sql
 ```
 
 ### SQLite (`--format sqlite`)

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -6,7 +6,7 @@ Use `--format` to declare the SQL dialect of your input file:
 
 | Value | Description |
 |---|---|
-| `postgres` (default) | PostgreSQL `pg_dump` plain-text format. Supports `COPY … FROM stdin` blocks, `"double-quoted"` identifiers, `''`-escaped strings. Custom-format (`-Fc`) or directory dumps can be decoded on the fly with `dumpling --dump-decode` (wraps `pg_restore -f -`; requires client tools). |
+| `postgres` (default) | PostgreSQL `pg_dump` plain-text format. Supports `COPY … FROM stdin` blocks, `"double-quoted"` identifiers, `''`-escaped strings. Custom-format (`-Fc`) or directory dumps can be decoded on the fly with `dumpling --dump-decode` (wraps `pg_restore -f -`; requires client tools). By default the archive is deleted after success; use `--dump-decode-keep-input` to retain it. |
 | `sqlite` | SQLite `.dump` format. Adds `INSERT OR REPLACE INTO` / `INSERT OR IGNORE INTO` support. No COPY blocks. |
 | `mssql` | SQL Server / MSSQL plain SQL. Adds `[bracket]` identifier quoting, `N'…'` Unicode string literals, and `nvarchar(n)` / `nchar(n)` length extraction. No COPY blocks. |
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -17,6 +17,28 @@ dumpling --format sqlite -i data.db.sql -o anonymized.sql
 dumpling --format mssql  -i backup.sql  -o anonymized.sql
 ```
 
+### PostgreSQL custom-format archives (`--dump-decode`)
+
+Heroku PGBackups and many pipelines ship **`pg_dump` custom format** (`-Fc`) or **directory-format** dumps to save bandwidth. Dumpling’s SQL engine still expects **plain text**; use **`--dump-decode`** so Dumpling runs **`pg_restore -f -`** (script to stdout, no database) and pipes the result through the same anonymizer as a normal plain-SQL file.
+
+**Requirements:** PostgreSQL client tools on `PATH` (`pg_restore`), or set **`--pg-restore-path`**. Use **`--dump-decode-arg`** (repeatable) for extra `pg_restore` flags, e.g. `--dump-decode-arg=--no-owner --dump-decode-arg=--no-acl`.
+
+**Input deletion:** After a **fully successful** run, Dumpling **removes** the `--input` path (single file or directory-format folder) by default so only the anonymized output remains. Pass **`--dump-decode-keep-input`** to retain the archive.
+
+**Check mode:** **`--check`** with **`--dump-decode`** requires **`--dump-decode-keep-input`**. Otherwise the default would delete the dump before you can iterate on config.
+
+Example (e.g. after `heroku pg:backups:download`):
+
+```bash
+dumpling --dump-decode -i latest.dump -c .dumplingconf -o anonymized.sql
+```
+
+Dry run while keeping the downloaded file:
+
+```bash
+dumpling --dump-decode --dump-decode-keep-input --check -i latest.dump -c .dumplingconf
+```
+
 ---
 
 ## Configuration sources

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -6,7 +6,7 @@ Use `--format` to declare the SQL dialect of your input file:
 
 | Value | Description |
 |---|---|
-| `postgres` (default) | PostgreSQL `pg_dump` plain-text format. Supports `COPY … FROM stdin` blocks, `"double-quoted"` identifiers, `''`-escaped strings. |
+| `postgres` (default) | PostgreSQL `pg_dump` plain-text format. Supports `COPY … FROM stdin` blocks, `"double-quoted"` identifiers, `''`-escaped strings. Custom-format (`-Fc`) or directory dumps can be decoded on the fly with `dumpling --dump-decode` (wraps `pg_restore -f -`; requires client tools). |
 | `sqlite` | SQLite `.dump` format. Adds `INSERT OR REPLACE INTO` / `INSERT OR IGNORE INTO` support. No COPY blocks. |
 | `mssql` | SQL Server / MSSQL plain SQL. Adds `[bracket]` identifier quoting, `N'…'` Unicode string literals, and `nvarchar(n)` / `nchar(n)` length extraction. No COPY blocks. |
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -28,4 +28,6 @@ cargo test --all-targets --all-features
 dumpling -i dump.sql -o sanitized.sql
 ```
 
+If your input is a PostgreSQL **custom-format** file (not plain SQL), decode and anonymize in one step with **`--dump-decode`** (needs `pg_restore` from PostgreSQL client tools). See [PostgreSQL custom-format archives](configuration.md#postgresql-custom-format-archives---dump-decode) in the configuration guide.
+
 For full command examples and strategy options, see the repository `README.md`.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 # Dumpling documentation
 
-Dumpling is a streaming anonymizer for plain SQL dumps. It supports PostgreSQL (`pg_dump` plain format), SQLite (`.dump`), and SQL Server / MSSQL (SSMS / mssql-scripter plain SQL output).
+Dumpling is a streaming anonymizer for plain SQL dumps. It supports PostgreSQL (`pg_dump` plain format), SQLite (`.dump`), and SQL Server / MSSQL (SSMS / mssql-scripter plain SQL output). For PostgreSQL **custom-format** archives (e.g. Heroku `pg:backups:download`), use **`--dump-decode`** so Dumpling invokes `pg_restore` and streams plain SQL—see [Dump format](configuration.html#postgresql-custom-format-archives---dump-decode) in the configuration guide.
 
 This documentation covers the operating model for day-to-day use:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 use clap::{ArgAction, Parser, Subcommand};
 
@@ -13,6 +14,7 @@ mod settings;
 mod sql;
 mod transform;
 
+use anyhow::Context;
 use regex::Regex;
 use report::Reporter;
 use scan::{OutputScanner, ScanningWriter};
@@ -105,6 +107,26 @@ struct Cli {
     #[arg(long = "security-profile", default_value = "standard")]
     security_profile: String,
 
+    /// Decode PostgreSQL custom-format or directory-format dumps via `pg_restore -f -` before anonymizing.
+    /// Requires `--input` pointing at the archive file or directory and `--format postgres`. Requires a
+    /// PostgreSQL client install (`pg_restore` on PATH unless overridden by `--pg-restore-path`).
+    #[arg(long = "dump-decode", action = ArgAction::SetTrue)]
+    dump_decode: bool,
+
+    /// After a successful run with `--dump-decode`, delete the input archive file or directory.
+    /// Ignored if anonymization fails or `pg_restore` exits non-zero.
+    #[arg(long = "dump-decode-delete-input", action = ArgAction::SetTrue)]
+    dump_decode_delete_input: bool,
+
+    /// `pg_restore` executable to use with `--dump-decode` (default: `pg_restore` on PATH).
+    #[arg(long = "pg-restore-path", default_value = "pg_restore")]
+    pg_restore_path: PathBuf,
+
+    /// Extra arguments forwarded to `pg_restore` before the archive path (repeatable). Example:
+    /// `--dump-decode-arg=--no-owner` `--dump-decode-arg=--no-acl`
+    #[arg(long = "dump-decode-arg")]
+    dump_decode_arg: Vec<String>,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -184,6 +206,12 @@ fn run_anonymize(cli: Cli) -> anyhow::Result<()> {
     if cli.check && (cli.in_place || cli.output.is_some()) {
         anyhow::bail!("--check cannot be used together with --output or --in-place");
     }
+    if cli.dump_decode && cli.dump_decode_delete_input && cli.check {
+        anyhow::bail!("--dump-decode-delete-input cannot be used with --check");
+    }
+    if cli.dump_decode && cli.in_place {
+        anyhow::bail!("--dump-decode cannot be used with --in-place");
+    }
 
     // Resolve config from provided path or discover in CWD
     let resolved_config: ResolvedConfig =
@@ -247,36 +275,97 @@ fn run_anonymize(cli: Cli) -> anyhow::Result<()> {
             other
         ),
     };
+    if cli.dump_decode && dump_format != DumpFormat::Postgres {
+        anyhow::bail!(
+            "--dump-decode only applies to PostgreSQL dumps; use --format postgres (default)"
+        );
+    }
 
     // Compile table include/exclude regex patterns
     let include_res = compile_patterns(&cli.include_table)?;
     let exclude_res = compile_patterns(&cli.exclude_table)?;
 
-    // Determine IO
-    let (mut reader, input_path_for_inplace): (Box<dyn BufRead>, Option<PathBuf>) = match &cli.input
+    // Determine IO (optional pg_restore child when --dump-decode)
+    let mut pg_restore_child: Option<std::process::Child> = None;
+    let (mut reader, input_path_for_inplace): (Box<dyn BufRead>, Option<PathBuf>) = if cli
+        .dump_decode
     {
-        Some(path) => {
-            // Enforce extension allowlist if provided
-            if !cli.allow_ext.is_empty() && !has_allowed_extension(path, &cli.allow_ext) {
-                let actual = path
-                    .extension()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("<none>")
-                    .to_string();
-                anyhow::bail!(
-                    "input file extension '{}' is not in allowed set {:?}",
-                    actual,
-                    cli.allow_ext
-                );
-            }
-            let f = File::open(path)?;
-            (Box::new(BufReader::new(f)), Some(path.clone()))
+        let archive_path = cli
+                .input
+                .as_ref()
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "--dump-decode requires --input pointing at a pg_dump custom-format file or directory-format directory"
+                    )
+                })?;
+        if !cli.allow_ext.is_empty() && !has_allowed_extension(archive_path, &cli.allow_ext) {
+            let actual = archive_path
+                .extension()
+                .and_then(|s| s.to_str())
+                .unwrap_or("<none>")
+                .to_string();
+            anyhow::bail!(
+                "input file extension '{}' is not in allowed set {:?}",
+                actual,
+                cli.allow_ext
+            );
         }
-        None => {
-            if !cli.allow_ext.is_empty() {
-                eprintln!("dumpling: --allow-ext provided but no --input file; extension check is ignored for stdin");
+        if !archive_path.exists() {
+            anyhow::bail!(
+                "--dump-decode input path does not exist: {}",
+                archive_path.display()
+            );
+        }
+        eprintln!(
+            "dumpling: decoding PostgreSQL archive via {} -f - {}",
+            cli.pg_restore_path.display(),
+            archive_path.display()
+        );
+        let mut cmd = Command::new(&cli.pg_restore_path);
+        for a in &cli.dump_decode_arg {
+            cmd.arg(a);
+        }
+        cmd.arg("-f")
+            .arg("-")
+            .arg(archive_path)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+        let mut child = cmd.spawn().with_context(|| {
+            format!(
+                "failed to spawn `{}`; install PostgreSQL client tools or set --pg-restore-path",
+                cli.pg_restore_path.display()
+            )
+        })?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("pg_restore stdout missing"))?;
+        pg_restore_child = Some(child);
+        (Box::new(BufReader::new(stdout)), Some(archive_path.clone()))
+    } else {
+        match &cli.input {
+            Some(path) => {
+                if !cli.allow_ext.is_empty() && !has_allowed_extension(path, &cli.allow_ext) {
+                    let actual = path
+                        .extension()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("<none>")
+                        .to_string();
+                    anyhow::bail!(
+                        "input file extension '{}' is not in allowed set {:?}",
+                        actual,
+                        cli.allow_ext
+                    );
+                }
+                let f = File::open(path)?;
+                (Box::new(BufReader::new(f)), Some(path.clone()))
             }
-            (Box::new(BufReader::new(io::stdin())), None)
+            None => {
+                if !cli.allow_ext.is_empty() {
+                    eprintln!("dumpling: --allow-ext provided but no --input file; extension check is ignored for stdin");
+                }
+                (Box::new(BufReader::new(io::stdin())), None)
+            }
         }
     };
 
@@ -330,12 +419,30 @@ fn run_anonymize(cli: Cli) -> anyhow::Result<()> {
         dump_format,
     );
     let mut writer = output;
-    if let Some(scanner) = output_scanner.as_mut() {
+    let proc_res = if let Some(scanner) = output_scanner.as_mut() {
         let mut scanning_writer = ScanningWriter::new(&mut writer, scanner);
-        processor.process(&mut reader, &mut scanning_writer)?;
+        processor.process(&mut reader, &mut scanning_writer)
     } else {
-        processor.process(&mut reader, &mut writer)?;
+        processor.process(&mut reader, &mut writer)
+    };
+
+    if let Some(mut child) = pg_restore_child {
+        if proc_res.is_err() {
+            let _ = child.kill();
+        }
+        let status = child
+            .wait()
+            .with_context(|| format!("waiting for `{}`", cli.pg_restore_path.display()))?;
+        if proc_res.is_ok() && !status.success() {
+            anyhow::bail!(
+                "`{}` exited with status {}",
+                cli.pg_restore_path.display(),
+                status
+            );
+        }
     }
+
+    proc_res?;
     let coverage = processor.sensitive_coverage_summary();
     reporter.report.sensitive_columns_detected = coverage.detected.clone();
     reporter.report.sensitive_columns_covered = coverage.covered.clone();
@@ -363,7 +470,10 @@ fn run_anonymize(cli: Cli) -> anyhow::Result<()> {
 
     // If in-place, do the swap now
     if cli.in_place {
-        let input_path = input_path_for_inplace.unwrap();
+        let input_path = input_path_for_inplace
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("--in-place requires an --input path"))?
+            .clone();
         let mut tmp = input_path.clone();
         tmp.set_extension("sql.dumpling.tmp");
         writer.flush()?;
@@ -405,7 +515,28 @@ fn run_anonymize(cli: Cli) -> anyhow::Result<()> {
         std::process::exit(1);
     }
 
+    if cli.dump_decode_delete_input && cli.dump_decode {
+        if let Some(ref p) = input_path_for_inplace {
+            match remove_pg_archive(p) {
+                Ok(()) => eprintln!("dumpling: removed input archive {}", p.display()),
+                Err(e) => eprintln!(
+                    "dumpling: warning: could not remove input archive {}: {}",
+                    p.display(),
+                    e
+                ),
+            }
+        }
+    }
+
     Ok(())
+}
+
+fn remove_pg_archive(path: &Path) -> std::io::Result<()> {
+    if path.is_dir() {
+        std::fs::remove_dir_all(path)
+    } else {
+        std::fs::remove_file(path)
+    }
 }
 
 fn compile_patterns(patterns: &[String]) -> anyhow::Result<Vec<Regex>> {
@@ -492,6 +623,24 @@ mod tests_main {
             }
             _ => panic!("expected LintPolicy subcommand"),
         }
+    }
+
+    #[test]
+    fn test_dump_decode_flags_parse() {
+        let cli = Cli::parse_from([
+            "dumpling",
+            "--dump-decode",
+            "--dump-decode-delete-input",
+            "--pg-restore-path",
+            "/usr/bin/pg_restore",
+            "--dump-decode-arg=--no-owner",
+            "-i",
+            "/tmp/latest.dump",
+        ]);
+        assert!(cli.dump_decode);
+        assert!(cli.dump_decode_delete_input);
+        assert_eq!(cli.pg_restore_path, PathBuf::from("/usr/bin/pg_restore"));
+        assert_eq!(cli.dump_decode_arg, vec!["--no-owner"]);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,10 +113,10 @@ struct Cli {
     #[arg(long = "dump-decode", action = ArgAction::SetTrue)]
     dump_decode: bool,
 
-    /// After a successful run with `--dump-decode`, delete the input archive file or directory.
-    /// Ignored if anonymization fails or `pg_restore` exits non-zero.
-    #[arg(long = "dump-decode-delete-input", action = ArgAction::SetTrue)]
-    dump_decode_delete_input: bool,
+    /// Keep the input archive after `--dump-decode` (default: delete file or directory after a fully
+    /// successful run). Cannot retain the archive with `--check` (would delete before verifying changes).
+    #[arg(long = "dump-decode-keep-input", action = ArgAction::SetTrue)]
+    dump_decode_keep_input: bool,
 
     /// `pg_restore` executable to use with `--dump-decode` (default: `pg_restore` on PATH).
     #[arg(long = "pg-restore-path", default_value = "pg_restore")]
@@ -206,8 +206,10 @@ fn run_anonymize(cli: Cli) -> anyhow::Result<()> {
     if cli.check && (cli.in_place || cli.output.is_some()) {
         anyhow::bail!("--check cannot be used together with --output or --in-place");
     }
-    if cli.dump_decode && cli.dump_decode_delete_input && cli.check {
-        anyhow::bail!("--dump-decode-delete-input cannot be used with --check");
+    if cli.dump_decode && !cli.dump_decode_keep_input && cli.check {
+        anyhow::bail!(
+            "--dump-decode removes the input archive on success by default; use --dump-decode-keep-input with --check"
+        );
     }
     if cli.dump_decode && cli.in_place {
         anyhow::bail!("--dump-decode cannot be used with --in-place");
@@ -515,7 +517,7 @@ fn run_anonymize(cli: Cli) -> anyhow::Result<()> {
         std::process::exit(1);
     }
 
-    if cli.dump_decode_delete_input && cli.dump_decode {
+    if cli.dump_decode && !cli.dump_decode_keep_input {
         if let Some(ref p) = input_path_for_inplace {
             match remove_pg_archive(p) {
                 Ok(()) => eprintln!("dumpling: removed input archive {}", p.display()),
@@ -630,7 +632,7 @@ mod tests_main {
         let cli = Cli::parse_from([
             "dumpling",
             "--dump-decode",
-            "--dump-decode-delete-input",
+            "--dump-decode-keep-input",
             "--pg-restore-path",
             "/usr/bin/pg_restore",
             "--dump-decode-arg=--no-owner",
@@ -638,7 +640,7 @@ mod tests_main {
             "/tmp/latest.dump",
         ]);
         assert!(cli.dump_decode);
-        assert!(cli.dump_decode_delete_input);
+        assert!(cli.dump_decode_keep_input);
         assert_eq!(cli.pg_restore_path, PathBuf::from("/usr/bin/pg_restore"));
         assert_eq!(cli.dump_decode_arg, vec!["--no-owner"]);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **`--dump-decode`** (and related flags) so Dumpling can consume PostgreSQL **custom-format** (`pg_dump -Fc`) or **directory-format** archives—the same shape as Heroku `pg:backups:download`—without loading data into a database.

## Behavior

- With `--dump-decode`, Dumpling requires **`--input`** pointing at the archive file or directory and **`--format postgres`** (default).
- Spawns **`pg_restore`** with `-f -` (script to stdout), pipes stdout into the existing SQL anonymizer. Stderr from `pg_restore` is inherited (errors visible).
- After processing, waits on **`pg_restore`**; non-zero exit fails the run even if Dumpling finished reading (broken pipe cases).
- **By default** the input archive is **deleted** after a **fully successful** run. Use **`--dump-decode-keep-input`** to retain the file or directory. **`--check`** with `--dump-decode` **requires** `--dump-decode-keep-input` (otherwise the default would remove the dump before a meaningful check pass).
- **`--pg-restore-path`** (default `pg_restore`) and repeatable **`--dump-decode-arg`** for extras like `--no-owner`.

## Docs

- README PostgreSQL input section + example Heroku-style command.
- mdBook `configuration.md` table note.

## Tests

- CLI parse test for new flags.

PostgreSQL client tools remain an external dependency when using `--dump-decode`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://wearecrew.slack.com/archives/D09256HV0AJ/p1777745555955349?thread_ts=1777745555.955349&cid=D09256HV0AJ)

<div><a href="https://cursor.com/agents/bc-080bab9c-55f1-5aa0-a05c-4c2ab747d159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-080bab9c-55f1-5aa0-a05c-4c2ab747d159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

