### PR TITLE
README: hero logo, badges, snappier intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@
   <a href="https://github.com/ababic/dumpling"><strong>GitHub</strong></a>
 </p>
 
+<p align="center">
+  <sub><em>This project is entirely vibe-coded — with strong human guidance, review, and attention to quality and safety.</em></sub>
+</p>
+
 ---
 
 **Dumpling** reads plain-text SQL dumps (PostgreSQL `pg_dump`, SQLite `.dump`, SQL Server / MSSQL scripts) and rewrites sensitive columns using rules you define in TOML. Everything runs offline on files — ideal for CI, staging share-outs, and compliance-minded workflows.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 </p>
 
 <p align="center">
-  <sub><em>This project is entirely vibe-coded — with strong human guidance, review, and attention to quality and safety.</em></sub>
+  <sub><em>Disclaimer: This project is entirely vibe-coded — with strong human guidance, review, and attention to quality and safety.</em></sub>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,15 +1,41 @@
-# Dumpling
+<p align="center">
+  <img src="assets/logo.svg" width="140" height="140" alt="Dumpling logo: a dumpling with steam" />
+</p>
 
-**Dumpling** is a static anonymizer for plain SQL dumps. It supports PostgreSQL (`pg_dump` plain format), SQLite (`.dump`), and SQL Server / MSSQL (SSMS / mssql-scripter output). It lets you safely share, test with, or store database snapshots by replacing sensitive column data according to configurable rules — without ever touching a live database.
+<h1 align="center">Dumpling</h1>
+
+<p align="center">
+  <strong>Sanitize SQL dumps before they go anywhere.</strong><br />
+  Turn huge <code>pg_dump</code> / SQLite / SQL Server exports into shareable, test-friendly snapshots — no DB connection, no secrets left by accident.
+</p>
+
+<p align="center">
+  <a href="https://pypi.org/project/dumpling-cli/"><img src="https://img.shields.io/pypi/v/dumpling-cli.svg" alt="PyPI version" /></a>
+  <a href="https://pypi.org/project/dumpling-cli/"><img src="https://img.shields.io/pypi/pyversions/dumpling-cli.svg" alt="Python versions" /></a>
+  <a href="https://pypi.org/project/dumpling-cli/"><img src="https://img.shields.io/pypi/l/dumpling-cli.svg" alt="PyPI license" /></a>
+  <a href="https://github.com/ababic/dumpling/actions/workflows/tests.yml"><img src="https://github.com/ababic/dumpling/actions/workflows/tests.yml/badge.svg" alt="Tests" /></a>
+  <a href="https://github.com/ababic/dumpling/actions/workflows/ci.yml"><img src="https://github.com/ababic/dumpling/actions/workflows/ci.yml/badge.svg" alt="Lint" /></a>
+  <img src="https://img.shields.io/badge/rust-stable-orange?logo=rust" alt="Rust stable" />
+</p>
+
+<p align="center">
+  <a href="https://ababic.github.io/dumpling/"><strong>Documentation</strong></a>
+  &nbsp;·&nbsp;
+  <a href="https://github.com/ababic/dumpling"><strong>GitHub</strong></a>
+</p>
+
+---
+
+**Dumpling** reads plain-text SQL dumps (PostgreSQL `pg_dump`, SQLite `.dump`, SQL Server / MSSQL scripts) and rewrites sensitive columns using rules you define in TOML. Everything runs offline on files — ideal for CI, staging share-outs, and compliance-minded workflows.
 
 ## Why Dumpling?
 
-- **No live database required.** Works entirely on dump files; nothing connects to your database.
-- **Streaming and memory-efficient.** Processes dumps line by line, so even multi-gigabyte files stay manageable.
-- **Fail-safe by default.** If no configuration is found, Dumpling exits non-zero and tells you exactly where it looked. Silence is never mistaken for success.
-- **Deterministic anonymization.** Domain mappings ensure the same source value always produces the same pseudonym, keeping foreign-key relationships intact across tables.
-- **CI/CD ready.** `--check` mode, strict-coverage enforcement, JSON reports, and residual-PII scan gates plug cleanly into any pipeline.
-- **Flexible configuration.** Rules live in a `.dumplingconf` file or directly in `pyproject.toml` — no extra tooling needed.
+- **Offline by design** — works on dump files only; nothing connects to your database.
+- **Streams giant files** — line-by-line processing keeps multi‑GB dumps reasonable on modest hardware.
+- **Fails loud, not silent** — missing config exits non‑zero and lists where Dumpling looked; use `--allow-noop` only when you mean it.
+- **Stable pseudonyms** — optional domain mappings keep the same source value as the same fake value across tables (foreign keys stay consistent).
+- **Pipeline-ready** — `--check`, strict coverage, JSON reports, and residual PII scans fit pre-merge gates and release automation.
+- **Configure once** — `.dumplingconf` or `[tool.dumpling]` in `pyproject.toml`; install via **Rust** (`cargo`) or **`pip install dumpling-cli`**.
 
 ---
 

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="Dumpling logo">
+  <defs>
+    <linearGradient id="steam" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" stop-color="#e8f4fc" stop-opacity="0"/>
+      <stop offset="50%" stop-color="#cfe9fb" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#b8dff8" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="dough" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fff8ef"/>
+      <stop offset="45%" stop-color="#f4dcc4"/>
+      <stop offset="100%" stop-color="#e8b896"/>
+    </linearGradient>
+    <linearGradient id="shadow" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#c4865a" stop-opacity="0.35"/>
+      <stop offset="100%" stop-color="#8b5a3c" stop-opacity="0.15"/>
+    </linearGradient>
+  </defs>
+  <!-- Steam -->
+  <path fill="url(#steam)" d="M44 18c2-6 8-10 14-8s8 10 4 15c-3 4-2 9 2 12 5 4 5 12 0 16-6 5-16 4-20-3-2-4 0-9 4-11 3-2 3-6 0-9-4-4-4-10 0-12z"/>
+  <path fill="url(#steam)" opacity="0.75" d="M64 14c3-5 9-7 14-4 5 3 6 10 2 14-4 4-3 10 2 13 6 4 7 13 1 18-7 6-19 4-24-5-2-5 1-11 6-13 4-2 4-7 1-10-5-4-5-11 0-13z"/>
+  <path fill="url(#steam)" opacity="0.6" d="M82 20c2-5 8-8 13-5 5 3 7 10 3 15-3 4-2 9 3 12 5 3 7 11 2 16-6 6-17 5-22-3-2-4 0-9 5-11 3-2 4-6 1-9-4-4-4-10 0-13z"/>
+  <!-- Plate -->
+  <ellipse cx="64" cy="108" rx="52" ry="10" fill="#dfe8ef"/>
+  <ellipse cx="64" cy="106" rx="48" ry="8" fill="#eef4f8"/>
+  <!-- Dumpling body -->
+  <ellipse cx="64" cy="82" rx="42" ry="28" fill="url(#dough)" stroke="#d4a574" stroke-width="2"/>
+  <ellipse cx="64" cy="96" rx="38" ry="12" fill="url(#shadow)"/>
+  <!-- Pleats -->
+  <path fill="none" stroke="#c9956a" stroke-width="1.8" stroke-linecap="round" d="M34 58c6 10 14 16 30 16s24-6 30-16"/>
+  <path fill="none" stroke="#d9b08a" stroke-width="1.2" stroke-linecap="round" opacity="0.9" d="M42 54c5 8 13 13 22 13s17-5 22-13"/>
+  <!-- Highlight -->
+  <ellipse cx="48" cy="76" rx="10" ry="6" fill="#ffffff" opacity="0.35"/>
+</svg>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a centered hero at the top of `README.md`: SVG logo, short tagline, PyPI + CI + Rust badges (similar spirit to Ruff’s README), and quick links to docs and GitHub.
- Refreshes the opening copy and “Why Dumpling?” bullets for a broader audience while keeping the technical detail below unchanged.
- Adds a lighthearted disclaimer: “Disclaimer: … entirely vibe-coded … with strong human guidance, review, and attention to quality and safety.”

## Assets

- New `assets/logo.svg` — simple dumpling-with-steam illustration (inline SVG, no external deps).

## Notes

- Badge URLs assume repo `ababic/dumpling` and workflow files `tests.yml` / `ci.yml`; adjust if the fork/remote differs.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://wearecrew.slack.com/archives/D09256HV0AJ/p1777750100159769?thread_ts=1777750100.159769&cid=D09256HV0AJ)

<div><a href="https://cursor.com/agents/bc-5302ee76-f344-551e-bdf6-272c33ec0255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5302ee76-f344-551e-bdf6-272c33ec0255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

