### PR TITLE
Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-05-03
+
+### Fixed
+
+- **INSERT row parsing with JSON casts**: Values such as `'{"k":1}'::jsonb` are parsed so the cell’s unescaped payload is valid JSON for JSON path rules and anonymization; trailing casts like `::jsonb` / `::text` are preserved on output.
+
 ## [0.4.0] - 2026-05-02
 
 ### Added
@@ -55,6 +61,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Configurable output scan severities and per-category thresholds via `[output_scan]`.
 - JSON report section for output scan findings including category, count, threshold, severity, and sample locations.
 
+[0.4.1]: https://github.com/ababic/dumpling/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/ababic/dumpling/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/ababic/dumpling/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/ababic/dumpling/compare/v0.1.0...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "dumpling"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dumpling"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "dumpling-cli"
-version = "0.4.0"
+version = "0.4.1"
 description = "Static anonymizer for plain SQL dumps (PostgreSQL, SQLite, SQL Server)."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prepares **v0.4.1** as a patch release after the INSERT row parsing fix for JSON literals with trailing casts (`::jsonb`, `::text`, etc.), merged in #46.

## Changes

- Bump `dumpling` crate version in `Cargo.toml` and `Cargo.lock` to **0.4.1**.
- Bump `dumpling-cli` version in `pyproject.toml` to **0.4.1** (PyPI/maturin).
- Add **0.4.1** section to `CHANGELOG.md` with compare link.

## Post-merge

Per `docs/src/releasing.md`, after this merges to `main`:

```bash
git tag -a v0.4.1 -m "Release v0.4.1"
git push origin v0.4.1
```

That should drive the existing tag-based Release / Publish workflows.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://wearecrew.slack.com/archives/D09256HV0AJ/p1777803247931789?thread_ts=1777803247.931789&cid=D09256HV0AJ)

<div><a href="https://cursor.com/agents/bc-f0f4c262-ebc6-5020-8c02-d23153c61a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0f4c262-ebc6-5020-8c02-d23153c61a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

