### PR TITLE
fix: tolerate non-JSON cells for JSON path anonymization rules (#49)

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -229,20 +229,27 @@ fn apply_leaf_replacement(target: &mut serde_json::Value, repl: &Replacement) {
 }
 
 /// Mutate JSON document strings at configured paths using the same path semantics as predicates.
+///
+/// Returns [`None`] when `raw_json` is not valid strict JSON (same tolerance as row-filter JSON
+/// path extraction): path rules are skipped for that cell and callers should passthrough the
+/// original value unchanged.
 pub fn rewrite_json_paths_with_rules(
     registry: &AnonymizerRegistry,
     column_max_len: Option<usize>,
     json_rules: &[(Vec<String>, AnonymizerSpec)],
     raw_json: &str,
-) -> anyhow::Result<String> {
-    let mut root = serde_json::from_str::<serde_json::Value>(raw_json)?;
+) -> anyhow::Result<Option<String>> {
+    let mut root = match serde_json::from_str::<serde_json::Value>(raw_json) {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
     for (path, spec) in json_rules {
         let mut apply = |original_cell: Option<String>| {
             apply_anonymizer(registry, spec, original_cell.as_deref(), column_max_len)
         };
         mutate_json_at_path(&mut root, path, &mut apply)?;
     }
-    Ok(root.to_string())
+    Ok(Some(root.to_string()))
 }
 
 fn mutate_json_at_path<F>(
@@ -457,7 +464,7 @@ fn get_cached_regex(pat: &str, case_insensitive: bool) -> regex::Regex {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::{ResolvedConfig, RowFilterSet};
+    use crate::settings::{AnonymizerSpec, ResolvedConfig, RowFilterSet};
     use std::collections::HashMap;
 
     #[test]
@@ -629,5 +636,57 @@ mod tests {
             &cols,
             &[Some(r#"{"items":[{"kind":"secondary"}]}"#.to_string())]
         ));
+    }
+
+    #[test]
+    fn rewrite_json_paths_skips_non_json_cells_like_row_filters() {
+        let mut rules: HashMap<String, HashMap<String, AnonymizerSpec>> = HashMap::new();
+        let spec = AnonymizerSpec {
+            strategy: "string".to_string(),
+            salt: None,
+            min: None,
+            max: None,
+            length: Some(4),
+            min_days: None,
+            max_days: None,
+            min_seconds: None,
+            max_seconds: None,
+            domain: None,
+            unique_within_domain: None,
+            as_string: Some(true),
+            locale: None,
+            faker: None,
+            format: None,
+        };
+        rules.insert("public.t".to_string(), HashMap::new());
+        let cfg = ResolvedConfig {
+            salt: None,
+            rules,
+            row_filters: HashMap::new(),
+            column_cases: HashMap::new(),
+            sensitive_columns: HashMap::new(),
+            output_scan: crate::settings::OutputScanConfig::default(),
+            source_path: None,
+        };
+        let registry = AnonymizerRegistry::from_config(&cfg);
+        let json_rules: Vec<(Vec<String>, AnonymizerSpec)> = vec![(
+            vec!["profile".to_string(), "secret".to_string()],
+            spec.clone(),
+        )];
+        assert!(
+            rewrite_json_paths_with_rules(&registry, None, &json_rules, "{not json")
+                .unwrap()
+                .is_none()
+        );
+        let out = rewrite_json_paths_with_rules(
+            &registry,
+            None,
+            &json_rules,
+            r#"{"profile":{"secret":"x"}}"#,
+        )
+        .unwrap()
+        .expect("valid JSON should rewrite");
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_ne!(v["profile"]["secret"], "x");
     }
 }

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -562,7 +562,11 @@ impl SqlStreamProcessor {
             None => return Ok(None),
         };
         let specs: Vec<AnonymizerSpec> = json_owned.iter().map(|(_, s)| s.clone()).collect();
-        let out = rewrite_json_paths_with_rules(&self.anonymizers, col_len, &json_owned, raw)?;
+        let Some(out) =
+            rewrite_json_paths_with_rules(&self.anonymizers, col_len, &json_owned, raw)?
+        else {
+            return Ok(None);
+        };
         let repl = Replacement::quoted(out);
         Ok(Some((repl, specs)))
     }
@@ -2395,6 +2399,76 @@ COPY public.events (id, payload) FROM stdin;
         assert_eq!(
             v_ins["profile"]["secret"], v_copy["profile"]["secret"],
             "INSERT and COPY must apply the same nested anonymization"
+        );
+    }
+
+    #[test]
+    fn pipeline_json_path_rules_passthrough_non_json_cells() {
+        let mut rules: HashMap<String, HashMap<String, AnonymizerSpec>> = HashMap::new();
+        let mut cols: HashMap<String, AnonymizerSpec> = HashMap::new();
+        cols.insert(
+            "payload.profile.secret".to_string(),
+            AnonymizerSpec {
+                strategy: "string".to_string(),
+                salt: None,
+                min: None,
+                max: None,
+                length: Some(8),
+                min_days: None,
+                max_days: None,
+                min_seconds: None,
+                max_seconds: None,
+                domain: Some("secrets".to_string()),
+                unique_within_domain: None,
+                as_string: Some(true),
+                locale: None,
+                faker: None,
+                format: None,
+            },
+        );
+        rules.insert("public.events".to_string(), cols);
+        let cfg = ResolvedConfig {
+            salt: None,
+            rules,
+            row_filters: HashMap::new(),
+            column_cases: HashMap::new(),
+            sensitive_columns: HashMap::new(),
+            output_scan: crate::settings::OutputScanConfig::default(),
+            source_path: None,
+        };
+        let reg = AnonymizerRegistry::from_config(&cfg);
+        let mut proc =
+            SqlStreamProcessor::new(reg, cfg, Vec::new(), Vec::new(), None, DumpFormat::Postgres);
+        let input = r#"
+CREATE TABLE public.events (id int, payload jsonb);
+INSERT INTO public.events (id, payload) VALUES
+  (1, '{not strict json}'),
+  (2, '{"profile":{"tier":"gold","secret":"alpha"}}');
+
+COPY public.events (id, payload) FROM stdin;
+3	{not strict json}
+4	{"profile":{"tier":"gold","secret":"alpha"}}
+\.
+"#;
+        let mut reader = std::io::BufReader::new(input.as_bytes());
+        let mut out = Vec::new();
+        proc.process(&mut reader, &mut out).unwrap();
+        let s = String::from_utf8(out).unwrap();
+        assert!(
+            s.contains("(1, '{not strict json}')"),
+            "non-JSON INSERT cell should passthrough unchanged, got:\n{s}"
+        );
+        assert!(
+            !s.contains("alpha"),
+            "valid JSON INSERT row should still anonymize nested paths, got:\n{s}"
+        );
+        assert!(
+            s.contains("\n3\t{not strict json}\n"),
+            "non-JSON COPY cell should passthrough unchanged, got:\n{s}"
+        );
+        assert!(
+            !s.contains("\n4\t{\"profile\":{\"tier\":\"gold\",\"secret\":\"alpha\"}}\n"),
+            "valid JSON COPY row should anonymize nested secret, got:\n{s}"
         );
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [issue #49](https://github.com/ababic/dumpling/issues/49): when `[rules]` use dotted JSON path keys on a column, a single row whose cell does not parse as strict JSON with `serde_json` used to abort the whole run with an opaque parse error.

## Behavior

- **Before:** `rewrite_json_paths_with_rules` called `serde_json::from_str` and propagated `Err`, killing the process with no table/column context.
- **After:** Parse failure returns `Ok(None)`, matching row-filter semantics in `extract_json_path_targets` (parse errors → treat as non-match / skip). `apply_column_rules` then returns `Ok(None)` so the original cell is written unchanged for that row.

Valid JSON cells continue to have path rules applied as before.

## Tests

- `filter::tests::rewrite_json_paths_skips_non_json_cells_like_row_filters` — unit coverage for invalid vs valid JSON.
- `sql::tests::pipeline_json_path_rules_passthrough_non_json_cells` — INSERT + COPY pipeline with one bad cell and one good cell per format.

## Notes

- Non-JSON cells with **only** path rules are now **passed through unchanged** (including sensitive content). Users who need a hard failure for malformed JSON would need a follow-up config knob; this change prioritizes resilience as suggested in the issue.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://wearecrew.slack.com/archives/D09256HV0AJ/p1777809047554759?thread_ts=1777809047.554759&cid=D09256HV0AJ)

<div><a href="https://cursor.com/agents/bc-574ef2c8-5c26-5949-9c8f-9d8885debc99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-574ef2c8-5c26-5949-9c8f-9d8885debc99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

