### PR TITLE
fix: preserve JSON number/bool types for path-based anonymization

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -224,8 +224,94 @@ fn replacement_to_json_value(repl: &Replacement) -> serde_json::Value {
         .unwrap_or_else(|_| serde_json::Value::String(repl.value.clone()))
 }
 
+/// When rewriting JSON at a path, map `Replacement` back into [`serde_json::Value`] while keeping
+/// the leaf's JSON type when the strategy still returns text (e.g. `Replacement::quoted` for
+/// `string`, `hash`, etc.): numeric and boolean leaves stay JSON numbers/bools if the replacement
+/// text parses as such.
+fn coerce_json_path_replacement(
+    original: &serde_json::Value,
+    repl: &Replacement,
+) -> serde_json::Value {
+    if repl.is_null {
+        return serde_json::Value::Null;
+    }
+    match original {
+        serde_json::Value::Bool(_) => {
+            if let Some(b) = parse_loose_json_bool(&repl.value) {
+                return serde_json::Value::Bool(b);
+            }
+            if !repl.force_quoted {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&repl.value) {
+                    match v {
+                        serde_json::Value::Bool(b) => return serde_json::Value::Bool(b),
+                        serde_json::Value::Number(n) => {
+                            if n.as_u64() == Some(0) || n.as_i64() == Some(0) {
+                                return serde_json::Value::Bool(false);
+                            }
+                            if n.as_u64() == Some(1) || n.as_i64() == Some(1) {
+                                return serde_json::Value::Bool(true);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            serde_json::Value::String(repl.value.clone())
+        }
+        serde_json::Value::Number(_) => {
+            if let Some(n) = parse_loose_json_number(&repl.value) {
+                return serde_json::Value::Number(n);
+            }
+            if !repl.force_quoted {
+                if let Ok(serde_json::Value::Number(n)) =
+                    serde_json::from_str::<serde_json::Value>(&repl.value)
+                {
+                    return serde_json::Value::Number(n);
+                }
+            }
+            serde_json::Value::String(repl.value.clone())
+        }
+        serde_json::Value::String(_) => {
+            if repl.force_quoted {
+                serde_json::Value::String(repl.value.clone())
+            } else {
+                serde_json::from_str(&repl.value)
+                    .unwrap_or_else(|_| serde_json::Value::String(repl.value.clone()))
+            }
+        }
+        serde_json::Value::Null => replacement_to_json_value(repl),
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
+            replacement_to_json_value(repl)
+        }
+    }
+}
+
+fn parse_loose_json_bool(s: &str) -> Option<bool> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+fn parse_loose_json_number(s: &str) -> Option<serde_json::Number> {
+    let t = s.trim();
+    if t.is_empty() {
+        return None;
+    }
+    if let Ok(i) = t.parse::<i64>() {
+        return Some(i.into());
+    }
+    if let Ok(u) = t.parse::<u64>() {
+        return Some(u.into());
+    }
+    let f = t.parse::<f64>().ok()?;
+    serde_json::Number::from_f64(f)
+}
+
 fn apply_leaf_replacement(target: &mut serde_json::Value, repl: &Replacement) {
-    *target = replacement_to_json_value(repl);
+    let original = target.clone();
+    *target = coerce_json_path_replacement(&original, repl);
 }
 
 /// Mutate JSON document strings at configured paths using the same path semantics as predicates.
@@ -465,6 +551,7 @@ fn get_cached_regex(pat: &str, case_insensitive: bool) -> regex::Regex {
 mod tests {
     use super::*;
     use crate::settings::{AnonymizerSpec, ResolvedConfig, RowFilterSet};
+    use crate::transform::AnonymizerRegistry;
     use std::collections::HashMap;
 
     #[test]
@@ -688,5 +775,88 @@ mod tests {
         .expect("valid JSON should rewrite");
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_ne!(v["profile"]["secret"], "x");
+    }
+
+    #[test]
+    fn rewrite_json_paths_preserves_number_and_bool_leaf_types_for_quoted_replacements() {
+        let mut rules: HashMap<String, HashMap<String, AnonymizerSpec>> = HashMap::new();
+        rules.insert("public.t".to_string(), HashMap::new());
+        let cfg = ResolvedConfig {
+            salt: None,
+            rules,
+            row_filters: HashMap::new(),
+            column_cases: HashMap::new(),
+            sensitive_columns: HashMap::new(),
+            output_scan: crate::settings::OutputScanConfig::default(),
+            source_path: None,
+        };
+        let registry = AnonymizerRegistry::from_config(&cfg);
+
+        let int_spec = AnonymizerSpec {
+            strategy: "int_range".to_string(),
+            salt: None,
+            min: Some(0),
+            max: Some(9),
+            length: None,
+            min_days: None,
+            max_days: None,
+            min_seconds: None,
+            max_seconds: None,
+            domain: Some("coerce_int_leaf".to_string()),
+            unique_within_domain: None,
+            as_string: None,
+            locale: None,
+            faker: None,
+            format: None,
+        };
+        let out = rewrite_json_paths_with_rules(
+            &registry,
+            None,
+            &[(vec!["n".to_string()], int_spec)],
+            r#"{"n":1,"b":true,"s":"x"}"#,
+        )
+        .unwrap()
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(
+            v["n"].is_number(),
+            "int_range replacement should stay JSON number, got {:?}",
+            v["n"]
+        );
+        assert_eq!(v["b"], true);
+        assert_eq!(v["s"], "x");
+
+        let string_spec = AnonymizerSpec {
+            strategy: "int_range".to_string(),
+            salt: None,
+            min: Some(0),
+            max: Some(0),
+            length: None,
+            min_days: None,
+            max_days: None,
+            min_seconds: None,
+            max_seconds: None,
+            domain: Some("coerce_bool_leaf".to_string()),
+            unique_within_domain: None,
+            as_string: None,
+            locale: None,
+            faker: None,
+            format: None,
+        };
+        let out2 = rewrite_json_paths_with_rules(
+            &registry,
+            None,
+            &[(vec!["b".to_string()], string_spec)],
+            r#"{"b":false}"#,
+        )
+        .unwrap()
+        .unwrap();
+        let v2: serde_json::Value = serde_json::from_str(&out2).unwrap();
+        assert!(
+            v2["b"].is_boolean(),
+            "unquoted 0 from int_range should coerce to bool at bool leaf, got {:?}",
+            v2["b"]
+        );
+        assert_eq!(v2["b"], false);
     }
 }

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -2473,6 +2473,86 @@ COPY public.events (id, payload) FROM stdin;
     }
 
     #[test]
+    fn pipeline_json_path_int_range_preserves_json_number_type() {
+        let mut rules: HashMap<String, HashMap<String, AnonymizerSpec>> = HashMap::new();
+        let mut cols: HashMap<String, AnonymizerSpec> = HashMap::new();
+        cols.insert(
+            "payload.score".to_string(),
+            AnonymizerSpec {
+                strategy: "int_range".to_string(),
+                salt: None,
+                min: Some(0),
+                max: Some(100),
+                length: None,
+                min_days: None,
+                max_days: None,
+                min_seconds: None,
+                max_seconds: None,
+                domain: Some("pipeline_json_num".to_string()),
+                unique_within_domain: None,
+                as_string: None,
+                locale: None,
+                faker: None,
+                format: None,
+            },
+        );
+        rules.insert("public.events".to_string(), cols);
+        let cfg = ResolvedConfig {
+            salt: None,
+            rules,
+            row_filters: HashMap::new(),
+            column_cases: HashMap::new(),
+            sensitive_columns: HashMap::new(),
+            output_scan: crate::settings::OutputScanConfig::default(),
+            source_path: None,
+        };
+        let reg = AnonymizerRegistry::from_config(&cfg);
+        let mut proc =
+            SqlStreamProcessor::new(reg, cfg, Vec::new(), Vec::new(), None, DumpFormat::Postgres);
+        let input = r#"
+CREATE TABLE public.events (id int, payload jsonb);
+INSERT INTO public.events (id, payload) VALUES
+  (1, '{"score":42,"label":"x"}');
+
+COPY public.events (id, payload) FROM stdin;
+2	{"score":42,"label":"x"}
+\.
+"#;
+        let mut reader = std::io::BufReader::new(input.as_bytes());
+        let mut out = Vec::new();
+        proc.process(&mut reader, &mut out).unwrap();
+        let s = String::from_utf8(out).unwrap();
+        let insert_pos = s.find("INSERT INTO public.events").unwrap();
+        let insert_tail = &s[insert_pos..];
+        let insert_end = insert_tail.find(";\n").unwrap() + insert_pos;
+        let ins_stmt = &s[insert_pos..=insert_end];
+        let vals_idx = ins_stmt.to_uppercase().find("VALUES").unwrap();
+        let ins_block = strip_trailing_semicolon(ins_stmt[vals_idx + "VALUES".len()..].trim());
+        let ins_rows = parse_values_rows(ins_block).unwrap();
+        let copy_line = s
+            .lines()
+            .find(|l| l.starts_with("2\t{"))
+            .expect("expected COPY data row");
+        let copy_json = copy_line.split_once('\t').unwrap().1;
+        let v_ins =
+            serde_json::from_str::<serde_json::Value>(ins_rows[0][1].original.as_ref().unwrap())
+                .unwrap();
+        let v_copy = serde_json::from_str::<serde_json::Value>(copy_json).unwrap();
+        assert!(
+            v_ins["score"].is_number(),
+            "INSERT payload.score should remain JSON number, got {:?}",
+            v_ins["score"]
+        );
+        assert!(
+            v_copy["score"].is_number(),
+            "COPY payload.score should remain JSON number, got {:?}",
+            v_copy["score"]
+        );
+        assert_eq!(v_ins["score"], v_copy["score"]);
+        assert_eq!(v_ins["label"], "x");
+    }
+
+    #[test]
     fn parse_values_rows_tracks_trailing_cast_for_quoted_literals() {
         let rows =
             parse_values_rows("(1, '{\"profile\":{\"secret\":\"alpha\"}}'::jsonb, 'note'::text)")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves JSON path anonymization so **numeric and boolean JSON leaves keep their JSON types** when strategies still emit `Replacement::quoted` (e.g. `string`, `hash`) or when unquoted text parses as a scalar.

## Implementation

- `coerce_json_path_replacement` in `filter.rs` maps each replacement using the **original leaf type**:
  - **Number leaf:** trim + parse as `i64` / `u64` / `f64` when possible; else same as before for `force_quoted: false` (`serde_json::from_str` for a JSON number).
  - **Bool leaf:** `true`/`false` (ASCII case-insensitive); for `force_quoted: false`, JSON bool or numeric **0**/**1** → bool (so deterministic `int_range` with a constant output can stay boolean).
  - **String / null / object / array leaves:** unchanged behavior (`replacement_to_json_value` for null and composite leaves).

- **Issue #49** behavior retained: `rewrite_json_paths_with_rules` returns `Ok(None)` on invalid JSON cells; `sql.rs` passthroughs the cell.

## Tests

- `filter::tests::rewrite_json_paths_preserves_number_and_bool_leaf_types_for_quoted_replacements` (domain-mapped `int_range` for stable assertions).
- `sql::tests::pipeline_json_path_int_range_preserves_json_number_type` (INSERT + COPY end-to-end).
- `pipeline_json_path_rules_passthrough_non_json_cells` (from #50 on main).

## Limits

- Replacements that are **not** parseable as numbers/bools still become JSON **strings** at numeric/boolean leaves (e.g. alphanumeric `string` output on a number field).
- **Float** precision may still differ from the source document after `serde_json` round-trip.

---

_Rebased onto latest `main` (includes #50); conflicts resolved in test modules._
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://wearecrew.slack.com/archives/D09256HV0AJ/p1777809047554759?thread_ts=1777809047.554759&cid=D09256HV0AJ)

<div><a href="https://cursor.com/agents/bc-574ef2c8-5c26-5949-9c8f-9d8885debc99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-574ef2c8-5c26-5949-9c8f-9d8885debc99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

