### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-03
+
 ### Added
 
 - **First-class strategies** `email`, `name`, `first_name`, `last_name`, and `phone` in config (same generators as `faker = "internet::SafeEmail"`, `name::Name`, `name::FirstName`, `name::LastName`, and locale-aware phone). Strategy names are normalized to lowercase at load.
@@ -15,6 +17,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - **Random-path faker/phone/PII**: one reused `StdRng` on `AnonymizerRegistry` instead of re-seeding per cell.
 - **`faker` locale resolution**: `resolved_locale_key` avoids allocating a `String` per faker call when locale is `en` or absent.
+
+### Performance
+
+- Larger default I/O buffers; fewer per-line and per-row allocations on the SQL stream path (INSERT/COPY parsing and row filters).
 
 ## [0.4.3] - 2026-05-03
 
@@ -83,6 +89,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Configurable output scan severities and per-category thresholds via `[output_scan]`.
 - JSON report section for output scan findings including category, count, threshold, severity, and sample locations.
 
+[0.5.0]: https://github.com/ababic/dumpling/compare/v0.4.3...v0.5.0
 [0.4.3]: https://github.com/ababic/dumpling/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/ababic/dumpling/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/ababic/dumpling/compare/v0.4.0...v0.4.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "dumpling"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dumpling"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 
 [dependencies]

--- a/docs/src/releasing.md
+++ b/docs/src/releasing.md
@@ -11,7 +11,7 @@ This project uses **tag-driven releases**.
 ## Maintainer checklist
 
 1. Ensure `main` is green in CI.
-2. Update `Cargo.toml` version and `CHANGELOG.md`.
+2. Update `Cargo.toml` and `pyproject.toml` versions and `CHANGELOG.md`.
 3. Open and merge a release preparation PR.
 4. Create and push a tag from `main`:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "dumpling-cli"
-version = "0.4.3"
+version = "0.5.0"
 description = "Static anonymizer for plain SQL dumps (PostgreSQL, SQLite, SQL Server)."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Release v0.5.0

Version bump for **Rust crate** (`Cargo.toml` / `Cargo.lock`) and **Python package** `dumpling-cli` (`pyproject.toml`). `CHANGELOG.md` moves the previous **[Unreleased]** notes into **[0.5.0]** and restores an empty Unreleased section. Docs: `docs/src/releasing.md` checklist now mentions `pyproject.toml`.

### Semver rationale (0.5.0 vs 0.4.4)

**0.5.0** is appropriate because:

- **Resolved config shape**: `email` / `name` / `first_name` / `last_name` stay as those strategy names after load instead of being rewritten to `faker`, which can break tools or tests that introspected `ResolvedConfig`.
- **Randomness sequencing**: random-path `faker` / `phone` / PII now share one `StdRng` on the registry; two back-to-back anonymizations that used to each re-seed can produce a **different sequence** than before for the same `--seed` (domain-mapped and deterministic paths are unchanged in intent).

Patch-only **0.4.4** would understate those behavioral/config-surface changes.

### After merge

From `main` after this PR lands:

```bash
git tag -a v0.5.0 -m "Release v0.5.0"
git push origin v0.5.0
```

Then confirm the Release / Publish workflow as in `docs/src/releasing.md`.

### Checks

- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets --all-features`
- `cargo fmt --all -- --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://wearecrew.slack.com/archives/D09256HV0AJ/p1777818539213179?thread_ts=1777818539.213179&cid=D09256HV0AJ)

<div><a href="https://cursor.com/agents/bc-a3f5b12c-77cb-5297-8a53-cb155016bff5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3f5b12c-77cb-5297-8a53-cb155016bff5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

