### PR TITLE
perf: Arc-backed replacement values and richer --stats

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,6 @@
+# Contributors
+
+Thank you to everyone who has helped improve Dumpling.
+
+- **Andy Babic** — creator and maintainer
+- **Jordan Hale** — performance and observability (including AI-assisted patches)

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -219,10 +219,10 @@ fn replacement_to_json_value(repl: &Replacement) -> serde_json::Value {
         return serde_json::Value::Null;
     }
     if repl.force_quoted {
-        return serde_json::Value::String(repl.value.clone());
+        return serde_json::Value::String(repl.value.as_ref().to_string());
     }
-    serde_json::from_str(&repl.value)
-        .unwrap_or_else(|_| serde_json::Value::String(repl.value.clone()))
+    serde_json::from_str(repl.value.as_ref())
+        .unwrap_or_else(|_| serde_json::Value::String(repl.value.as_ref().to_string()))
 }
 
 /// When rewriting JSON at a path, map `Replacement` back into [`serde_json::Value`] while keeping
@@ -238,11 +238,11 @@ fn coerce_json_path_replacement(
     }
     match original {
         serde_json::Value::Bool(_) => {
-            if let Some(b) = parse_loose_json_bool(&repl.value) {
+            if let Some(b) = parse_loose_json_bool(repl.value.as_ref()) {
                 return serde_json::Value::Bool(b);
             }
             if !repl.force_quoted {
-                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&repl.value) {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(repl.value.as_ref()) {
                     match v {
                         serde_json::Value::Bool(b) => return serde_json::Value::Bool(b),
                         serde_json::Value::Number(n) => {
@@ -257,27 +257,27 @@ fn coerce_json_path_replacement(
                     }
                 }
             }
-            serde_json::Value::String(repl.value.clone())
+            serde_json::Value::String(repl.value.as_ref().to_string())
         }
         serde_json::Value::Number(_) => {
-            if let Some(n) = parse_loose_json_number(&repl.value) {
+            if let Some(n) = parse_loose_json_number(repl.value.as_ref()) {
                 return serde_json::Value::Number(n);
             }
             if !repl.force_quoted {
                 if let Ok(serde_json::Value::Number(n)) =
-                    serde_json::from_str::<serde_json::Value>(&repl.value)
+                    serde_json::from_str::<serde_json::Value>(repl.value.as_ref())
                 {
                     return serde_json::Value::Number(n);
                 }
             }
-            serde_json::Value::String(repl.value.clone())
+            serde_json::Value::String(repl.value.as_ref().to_string())
         }
         serde_json::Value::String(_) => {
             if repl.force_quoted {
-                serde_json::Value::String(repl.value.clone())
+                serde_json::Value::String(repl.value.as_ref().to_string())
             } else {
-                serde_json::from_str(&repl.value)
-                    .unwrap_or_else(|_| serde_json::Value::String(repl.value.clone()))
+                serde_json::from_str(repl.value.as_ref())
+                    .unwrap_or_else(|_| serde_json::Value::String(repl.value.as_ref().to_string()))
             }
         }
         serde_json::Value::Null => replacement_to_json_value(repl),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
+use std::sync::atomic::Ordering;
 
 /// Larger than default 8 KiB to reduce syscall overhead on big dumps.
 const IO_BUF_CAPACITY: usize = 256 * 1024;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::time::Instant;
 
 use clap::{ArgAction, Parser, Subcommand};
 
@@ -486,6 +488,7 @@ fn run_anonymize(cli: Cli) -> anyhow::Result<()> {
     };
     let mut adapted_reader = FirstLineReplayBufRead::new(reader.as_mut(), replay_first);
 
+    let run_started = Instant::now();
     let proc_res: anyhow::Result<()> = if matches!(seal_first, SealFirstLine::TrustedPassthrough) {
         if let Some(ref digest) = seal_digest {
             writer.write_all(format_seal_line(security_profile_name, digest).as_bytes())?;
@@ -575,11 +578,23 @@ fn run_anonymize(cli: Cli) -> anyhow::Result<()> {
 
     // Emit stats or report if requested
     if cli.stats {
+        let elapsed_ms = run_started.elapsed().as_millis();
+        let domain_hits = processor
+            .anonymizers()
+            .domain_cache_hits
+            .load(Ordering::Relaxed);
+        let domain_misses = processor
+            .anonymizers()
+            .domain_cache_misses
+            .load(Ordering::Relaxed);
         eprintln!(
-            "dumpling: rows processed={}, rows dropped={}, cells changed={}",
+            "dumpling: rows processed={}, rows dropped={}, cells changed={}, wall_ms={}, domain_cache_hits={}, domain_cache_misses={}",
             reporter.report.total_rows_processed,
             reporter.report.total_rows_dropped,
-            reporter.report.total_cells_changed
+            reporter.report.total_cells_changed,
+            elapsed_ms,
+            domain_hits,
+            domain_misses
         );
     }
     if let Some(path) = cli.report.as_ref() {

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -98,6 +98,10 @@ impl SqlStreamProcessor {
         }
     }
 
+    pub fn anonymizers(&self) -> &AnonymizerRegistry {
+        &self.anonymizers
+    }
+
     pub fn process<R: BufRead, W: Write>(
         &mut self,
         reader: &mut R,
@@ -299,8 +303,9 @@ impl SqlStreamProcessor {
                                     if repl.is_null {
                                         new_fields.push(r"\N".to_string());
                                     } else {
-                                        new_fields
-                                            .push(escape_postgres_copy_text_field(&repl.value));
+                                        new_fields.push(escape_postgres_copy_text_field(
+                                            repl.value.as_ref(),
+                                        ));
                                     }
                                 }
                                 Err(e) => return Err(e),
@@ -1233,9 +1238,9 @@ fn render_cell(repl: &Replacement, original: &Cell) -> String {
     }
     let should_quote = repl.force_quoted || original.was_quoted;
     if should_quote {
-        format!("'{}'{trailing}", repl.value.replace('\'', "''"))
+        format!("'{}'{trailing}", repl.value.as_ref().replace('\'', "''"))
     } else {
-        format!("{}{trailing}", repl.value)
+        format!("{}{trailing}", repl.value.as_ref())
     }
 }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -11,7 +11,8 @@ use rand::SeedableRng;
 use sha2::{Digest, Sha256};
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -38,6 +39,10 @@ pub struct AnonymizerRegistry {
     domain_mappings: RefCell<HashMap<String, DomainMapping>>,
     /// Reused for `faker`, `phone`, and built-in PII strategies on the random (non-domain) path.
     faker_rng: RefCell<StdRng>,
+    /// Count of domain-map lookups that returned a cached pseudonym (for `--stats` / profiling).
+    pub domain_cache_hits: AtomicU64,
+    /// Count of domain-map lookups that computed a new pseudonym.
+    pub domain_cache_misses: AtomicU64,
 }
 
 static mut RNG_SEED_OVERRIDE: Option<u64> = None;
@@ -70,6 +75,8 @@ impl AnonymizerRegistry {
             security_profile: SecurityProfile::Standard,
             domain_mappings: RefCell::new(HashMap::new()),
             faker_rng: RefCell::new(make_random_rng()),
+            domain_cache_hits: AtomicU64::new(0),
+            domain_cache_misses: AtomicU64::new(0),
         }
     }
 }
@@ -77,7 +84,7 @@ impl AnonymizerRegistry {
 #[derive(Clone, Debug)]
 pub struct Replacement {
     /// The replacement value without surrounding SQL quotes
-    pub value: String,
+    pub value: Arc<str>,
     /// If true, force render as quoted literal
     pub force_quoted: bool,
     /// If true, render as NULL
@@ -87,21 +94,21 @@ pub struct Replacement {
 impl Replacement {
     pub fn null() -> Self {
         Self {
-            value: String::new(),
+            value: Arc::from(""),
             force_quoted: false,
             is_null: true,
         }
     }
     pub fn quoted<V: Into<String>>(v: V) -> Self {
         Self {
-            value: v.into(),
+            value: Arc::from(v.into()),
             force_quoted: true,
             is_null: false,
         }
     }
     pub fn unquoted<V: Into<String>>(v: V) -> Self {
         Self {
-            value: v.into(),
+            value: Arc::from(v.into()),
             force_quoted: false,
             is_null: false,
         }
@@ -121,7 +128,7 @@ pub fn apply_anonymizer(
     };
     if let Some(max_len) = column_max_len {
         if !replacement.is_null && should_enforce_max_len(spec.strategy.as_str()) {
-            replacement.value = truncate_to_max_chars(&replacement.value, max_len);
+            replacement.value = truncate_arc_str(replacement.value.clone(), max_len);
         }
     }
     replacement
@@ -151,8 +158,10 @@ fn apply_domain_anonymizer(
     let mut mappings = registry.domain_mappings.borrow_mut();
     let mapping = mappings.entry(domain_key.to_string()).or_default();
     if let Some(existing) = mapping.forward.get(original_value) {
+        registry.domain_cache_hits.fetch_add(1, Ordering::Relaxed);
         return existing.clone();
     }
+    registry.domain_cache_misses.fetch_add(1, Ordering::Relaxed);
 
     let enforce_unique = spec.unique_within_domain.unwrap_or(false);
     let mut collision_index: u64 = 0;
@@ -204,7 +213,7 @@ fn uniqueness_key(replacement: &Replacement) -> String {
     if replacement.is_null {
         "__NULL__".to_string()
     } else {
-        replacement.value.clone()
+        replacement.value.as_ref().to_string()
     }
 }
 
@@ -753,11 +762,11 @@ fn should_enforce_max_len(strategy: &str) -> bool {
     !matches!(strategy, "null" | "int_range")
 }
 
-fn truncate_to_max_chars(value: &str, max_len: usize) -> String {
+fn truncate_arc_str(value: Arc<str>, max_len: usize) -> Arc<str> {
     if value.chars().count() <= max_len {
-        return value.to_string();
+        return value;
     }
-    value.chars().take(max_len).collect()
+    Arc::from(value.chars().take(max_len).collect::<String>())
 }
 
 fn random_alnum(n: usize) -> String {
@@ -973,6 +982,8 @@ mod tests {
             security_profile: SecurityProfile::Standard,
             domain_mappings: RefCell::new(HashMap::new()),
             faker_rng: RefCell::new(make_random_rng()),
+            domain_cache_hits: AtomicU64::new(0),
+            domain_cache_misses: AtomicU64::new(0),
         }
     }
 
@@ -982,6 +993,8 @@ mod tests {
             security_profile: SecurityProfile::Hardened,
             domain_mappings: RefCell::new(HashMap::new()),
             faker_rng: RefCell::new(make_random_rng()),
+            domain_cache_hits: AtomicU64::new(0),
+            domain_cache_misses: AtomicU64::new(0),
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This change implements the two items we discussed: lightweight profiling via `--stats`, and cheaper handling of repeated domain-mapped values.

**`--stats`** now prints `wall_ms` (wall-clock time for the main SQL processing loop) plus `domain_cache_hits` and `domain_cache_misses` from relaxed atomics on the anonymizer registry. Together with the existing row/cell counters, this gives a quick read on whether a dump is spending effort on first-time domain mapping vs cache hits.

**Caching / allocations:** `Replacement::value` is now `Arc<str>`. New pseudonyms still allocate once when inserted into the domain forward map; subsequent hits clone the `Replacement` by bumping the `Arc` instead of cloning the full string. `varchar(N)` truncation replaces the `Arc` only when a length limit applies.

`SqlStreamProcessor::anonymizers()` exposes the registry for stats without making internal fields public beyond the existing pattern.

Rebased onto current `main` (including seal handling); `wall_ms` is measured from the start of the seal-adapted processing path (`io::copy` or `processor.process`).

Also adds `CONTRIBUTORS.md` listing project maintainer and contributors.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://wearecrew.slack.com/archives/D09256HV0AJ/p1777820979167579?thread_ts=1777820979.167579&cid=D09256HV0AJ)

<div><a href="https://cursor.com/agents/bc-7e6921c1-dd3e-5e8f-a3b6-cf0fe8dfea6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e6921c1-dd3e-5e8f-a3b6-cf0fe8dfea6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

