### PR TITLE
chore: bump version to 0.7.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
-## [0.7.0] - 2026-05-04
+## [0.7.0-alpha] - 2026-05-04
+
+Pre-release toward **0.7.0** (stable **0.7.0** is not published yet; crates use the **0.7.0-alpha** prerelease identifier until then).
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "dumpling"
-version = "0.7.0"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dumpling"
-version = "0.7.0"
+version = "0.7.0-alpha"
 edition = "2021"
 
 [dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "dumpling-cli"
-version = "0.7.0"
+version = "0.7.0-alpha"
 description = "Static anonymizer for plain SQL dumps (PostgreSQL, SQLite, SQL Server)."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bumps the Rust crate and Python package (`dumpling-cli`) version from **0.7.0** to **0.7.0-alpha** until a stable **0.7.0** release is published.

## Changes

- `Cargo.toml`, `pyproject.toml`, `Cargo.lock`
- `CHANGELOG.md`: documents **0.7.0-alpha** and notes that stable **0.7.0** is not released yet

No code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://wearecrew.slack.com/archives/D09256HV0AJ/p1777884491919159?thread_ts=1777884491.919159&cid=D09256HV0AJ)

<div><a href="https://cursor.com/agents/bc-9aa3f1f3-d9da-54cb-bd63-fdf4c74def2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9aa3f1f3-d9da-54cb-bd63-fdf4c74def2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

