### PR TITLE
fix: fail closed on invalid regex predicates (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ when.any = [
 strategy = { strategy = "email", domain = "user_email", unique_within_domain = true, as_string = true }
 ```
 
-Prefer positive `when` predicates (`ilike`, `in`, …) for the rows you want scrubbed; inverting “unless domain X” with `iregex` lookaround is not supported by Rust’s `regex` crate. When the allowlist is easier to express than the scrub set, use the `keep` cookbook above instead.
+Prefer positive `when` predicates (`ilike`, `in`, …) for the rows you want scrubbed; inverting “unless domain X” with `iregex` lookaround is **not supported** by Rust’s `regex` crate and is **rejected at config load**. Prefer the `keep` cookbook above when the allowlist is small; otherwise use `not_like` / `not_ilike` / `not_regex` / `not_iregex` (see Row filtering).
 
 ---
 
@@ -324,9 +324,24 @@ Supported predicate operators:
 | `eq` / `neq` | String compare (case-insensitive if `case_insensitive = true`) |
 | `in` / `not_in` | List of values (string compare) |
 | `like` / `ilike` | SQL-like patterns (`%` and `_`) |
-| `regex` / `iregex` | Rust regex (`iregex` is case-insensitive) |
+| `not_like` / `not_ilike` | Negation of `like` / `ilike` (prefer these over negative lookahead) |
+| `regex` / `iregex` | [Rust `regex`](https://docs.rs/regex/) crate (`iregex` is case-insensitive). **Not PCRE** — look-around (`(?!…)`, `(?=…)`, etc.), backreferences, and possessive quantifiers are unsupported and **rejected at config load** (fail closed). |
+| `not_regex` / `not_iregex` | Negation of `regex` / `iregex` |
 | `lt` / `lte` / `gt` / `gte` | Numeric compare (values parsed as numbers) |
 | `is_null` / `not_null` | No value needed |
+
+Invalid or unsupported `regex` / `iregex` / `not_regex` / `not_iregex` patterns fail config load (and `dumpling lint-policy`) instead of silently matching nothing.
+
+Example — blank non-staff emails without lookaround (staff rows match no case and pass through):
+
+```toml
+[[column_cases."public.users".email]]
+when.all = [
+  { column = "email", op = "not_ilike", value = "%@wearecrew.com" },
+  { column = "email", op = "not_ilike", value = "%@reskinned.clothing" },
+]
+strategy = { strategy = "blank" }
+```
 
 Predicates can target nested JSON values using dot notation (`payload.profile.tier`) or Django-style notation (`payload__profile__tier`). For JSON arrays, path segments are evaluated against each element, so list-of-dicts structures can be matched naturally.
 

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Supported predicate operators:
 
 Invalid or unsupported `regex` / `iregex` / `not_regex` / `not_iregex` patterns fail config load (and `dumpling lint-policy`) instead of silently matching nothing.
 
-Example — blank non-staff emails without lookaround (staff rows match no case and pass through):
+For “scrub unless staff domain” policies, prefer a default scrub plus a `keep` case (see Conditional cases cookbook above), or scrub via `not_ilike` / `not_iregex` cases without a default rule:
 
 ```toml
 [[column_cases."public.users".email]]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,8 +1,8 @@
 use crate::settings::{
-    lookup_row_filters, parse_json_column_key, AnonymizerSpec, Predicate, ResolvedConfig, When,
+    compile_regex_pattern, lookup_row_filters, parse_json_column_key, AnonymizerSpec, Predicate,
+    ResolvedConfig, When,
 };
 use crate::transform::{apply_anonymizer, AnonymizerRegistry, Replacement};
-use regex::RegexBuilder;
 use std::collections::HashMap;
 use std::sync::Mutex;
 
@@ -54,10 +54,13 @@ fn predicate_matches(pred: &Predicate, columns: &[String], cells: &[Option<&str>
         "not_null" => return targets.iter().any(|v| v.is_some()),
         _ => {}
     }
-    let case_insensitive = pred.case_insensitive.unwrap_or(matches!(op, "ilike"));
+    let case_insensitive = pred
+        .case_insensitive
+        .unwrap_or(matches!(op, "ilike" | "not_ilike"));
     // Fetch value(s)
     match op {
-        "eq" | "neq" | "like" | "ilike" | "lt" | "lte" | "gt" | "gte" | "regex" | "iregex" => {
+        "eq" | "neq" | "like" | "ilike" | "not_like" | "not_ilike" | "lt" | "lte" | "gt"
+        | "gte" | "regex" | "iregex" | "not_regex" | "not_iregex" => {
             let v = match &pred.value {
                 Some(v) => v,
                 None => return false,
@@ -69,12 +72,30 @@ fn predicate_matches(pred: &Predicate, columns: &[String], cells: &[Option<&str>
                 "neq" => !targets
                     .iter()
                     .any(|cell| cmp_eq(cell.as_deref(), v, case_insensitive)),
-                "like" | "ilike" => targets
-                    .iter()
-                    .any(|cell| cmp_like(cell.as_deref(), v, case_insensitive)),
-                "regex" | "iregex" => targets
-                    .iter()
-                    .any(|cell| cmp_regex(cell.as_deref(), v, case_insensitive || op == "iregex")),
+                "like" | "ilike" | "not_like" | "not_ilike" => {
+                    let matched = targets
+                        .iter()
+                        .any(|cell| cmp_like(cell.as_deref(), v, case_insensitive));
+                    if matches!(op, "like" | "ilike") {
+                        matched
+                    } else {
+                        !matched
+                    }
+                }
+                "regex" | "iregex" | "not_regex" | "not_iregex" => {
+                    let matched = targets.iter().any(|cell| {
+                        cmp_regex(
+                            cell.as_deref(),
+                            v,
+                            case_insensitive || matches!(op, "iregex" | "not_iregex"),
+                        )
+                    });
+                    if matches!(op, "regex" | "iregex") {
+                        matched
+                    } else {
+                        !matched
+                    }
+                }
                 "lt" => targets.iter().any(|cell| {
                     cmp_order(cell.as_deref(), v)
                         .map(|o| o < 0)
@@ -540,11 +561,13 @@ fn get_cached_regex(pat: &str, case_insensitive: bool) -> regex::Regex {
     if let Some(r) = REGEX_CACHE.lock().unwrap().get(&key) {
         return r.clone();
     }
-    let mut builder = RegexBuilder::new(pat);
-    builder.case_insensitive(case_insensitive);
-    let re = builder
-        .build()
-        .unwrap_or_else(|_| RegexBuilder::new("$^").build().unwrap());
+    // Config load validates regex/iregex patterns; LIKE conversion always yields a valid pattern.
+    let re = compile_regex_pattern(pat, case_insensitive).unwrap_or_else(|err| {
+        panic!(
+            "invalid regex pattern {pat:?} (case_insensitive={case_insensitive}): {err}; \
+             regex/iregex patterns are validated at config load"
+        )
+    });
     REGEX_CACHE.lock().unwrap().insert(key, re.clone());
     re
 }
@@ -623,6 +646,112 @@ mod tests {
             "users",
             &cols,
             &[Some("3"), Some("bob@example.com"), Some("US")]
+        ));
+    }
+
+    #[test]
+    fn not_like_and_not_iregex_predicates_work() {
+        let cfg = ResolvedConfig {
+            salt: None,
+            rules: HashMap::new(),
+            row_filters: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "public.users".to_string(),
+                    RowFilterSet {
+                        retain: vec![
+                            Predicate {
+                                column: "email".to_string(),
+                                op: "not_ilike".to_string(),
+                                value: Some(serde_json::json!("%@wearecrew.com")),
+                                values: None,
+                                case_insensitive: None,
+                            },
+                            Predicate {
+                                column: "email".to_string(),
+                                op: "not_iregex".to_string(),
+                                value: Some(serde_json::json!(".*@reskinned\\.clothing$")),
+                                values: None,
+                                case_insensitive: None,
+                            },
+                        ],
+                        delete: vec![],
+                    },
+                );
+                m
+            },
+            column_cases: HashMap::new(),
+            sensitive_columns: HashMap::new(),
+            output_scan: crate::settings::OutputScanConfig::default(),
+            pg_restore: crate::settings::PgRestoreConfig::default(),
+            keep_original: None,
+            source_path: None,
+        };
+        let cols = vec!["id".to_string(), "email".to_string()];
+        // Staff domains excluded by retain (not_ilike / not_iregex never both match staff)
+        // retain is OR: keep if either not_ilike OR not_iregex matches.
+        // wearecrew.com: not_ilike fails, not_iregex succeeds (not @reskinned) → keep
+        assert!(should_keep_row(
+            &cfg,
+            Some("public"),
+            "users",
+            &cols,
+            &[Some("1"), Some("andy@wearecrew.com")]
+        ));
+        // gmail: both not_* match → keep
+        assert!(should_keep_row(
+            &cfg,
+            Some("public"),
+            "users",
+            &cols,
+            &[Some("2"), Some("buyer@gmail.com")]
+        ));
+    }
+
+    #[test]
+    fn not_ilike_delete_drops_non_staff() {
+        // delete with not_ilike staff → drop everyone except staff
+        let cfg = ResolvedConfig {
+            salt: None,
+            rules: HashMap::new(),
+            row_filters: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "public.users".to_string(),
+                    RowFilterSet {
+                        retain: vec![],
+                        delete: vec![Predicate {
+                            column: "email".to_string(),
+                            op: "not_ilike".to_string(),
+                            value: Some(serde_json::json!("%@wearecrew.com")),
+                            values: None,
+                            case_insensitive: None,
+                        }],
+                    },
+                );
+                m
+            },
+            column_cases: HashMap::new(),
+            sensitive_columns: HashMap::new(),
+            output_scan: crate::settings::OutputScanConfig::default(),
+            pg_restore: crate::settings::PgRestoreConfig::default(),
+            keep_original: None,
+            source_path: None,
+        };
+        let cols = vec!["email".to_string()];
+        assert!(should_keep_row(
+            &cfg,
+            Some("public"),
+            "users",
+            &cols,
+            &[Some("andy@WeAreCrew.com")]
+        ));
+        assert!(!should_keep_row(
+            &cfg,
+            Some("public"),
+            "users",
+            &cols,
+            &[Some("buyer@gmail.com")]
         ));
     }
 

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -1,4 +1,4 @@
-use crate::settings::ResolvedConfig;
+use crate::settings::{compile_regex_pattern, ResolvedConfig};
 use std::collections::{HashMap, HashSet};
 
 /// A single policy violation emitted by `lint_policy`.
@@ -39,6 +39,7 @@ pub fn lint_policy(cfg: &ResolvedConfig) -> Vec<LintViolation> {
     check_unsalted_hash(cfg, &mut violations);
     check_inconsistent_domain_strategy(cfg, &mut violations);
     check_uncovered_sensitive_columns(cfg, &mut violations);
+    check_invalid_regex_predicates(cfg, &mut violations);
 
     violations
 }
@@ -235,6 +236,106 @@ fn check_uncovered_sensitive_columns(cfg: &ResolvedConfig, violations: &mut Vec<
                     severity: Severity::Error,
                 });
             }
+        }
+    }
+}
+
+/// Compile every `regex` / `iregex` / `not_regex` / `not_iregex` predicate pattern.
+/// Config load already rejects invalid patterns; this is a belt-and-suspenders check for
+/// `ResolvedConfig` values that may have bypassed `validate_raw_config`.
+fn check_invalid_regex_predicates(cfg: &ResolvedConfig, violations: &mut Vec<LintViolation>) {
+    let mut paths: Vec<(String, &crate::settings::Predicate)> = Vec::new();
+
+    let mut filter_tables: Vec<&str> = cfg.row_filters.keys().map(|k| k.as_str()).collect();
+    filter_tables.sort_unstable();
+    for table in filter_tables {
+        let set = &cfg.row_filters[table];
+        for (idx, pred) in set.retain.iter().enumerate() {
+            paths.push((format!("row_filters.\"{}\".retain[{}]", table, idx), pred));
+        }
+        for (idx, pred) in set.delete.iter().enumerate() {
+            paths.push((format!("row_filters.\"{}\".delete[{}]", table, idx), pred));
+        }
+    }
+
+    let mut case_tables: Vec<&str> = cfg.column_cases.keys().map(|k| k.as_str()).collect();
+    case_tables.sort_unstable();
+    for table in case_tables {
+        let cols = &cfg.column_cases[table];
+        let mut col_names: Vec<&str> = cols.keys().map(|c| c.as_str()).collect();
+        col_names.sort_unstable();
+        for col in col_names {
+            for (idx, case) in cols[col].iter().enumerate() {
+                for (pidx, pred) in case.when.any.iter().enumerate() {
+                    paths.push((
+                        format!(
+                            "column_cases.\"{}\".{}[{}].when.any[{}]",
+                            table, col, idx, pidx
+                        ),
+                        pred,
+                    ));
+                }
+                for (pidx, pred) in case.when.all.iter().enumerate() {
+                    paths.push((
+                        format!(
+                            "column_cases.\"{}\".{}[{}].when.all[{}]",
+                            table, col, idx, pidx
+                        ),
+                        pred,
+                    ));
+                }
+            }
+        }
+    }
+
+    for (path, pred) in paths {
+        let op = pred.op.as_str();
+        if !matches!(op, "regex" | "iregex" | "not_regex" | "not_iregex") {
+            continue;
+        }
+        let Some(value) = pred.value.as_ref() else {
+            violations.push(LintViolation {
+                code: "invalid-regex-predicate".to_string(),
+                message: format!("{}: operator '{}' requires a 'value' pattern", path, op),
+                severity: Severity::Error,
+            });
+            continue;
+        };
+        let pat = match value {
+            serde_json::Value::String(s) => s.clone(),
+            serde_json::Value::Number(n) => n.to_string(),
+            serde_json::Value::Bool(b) => {
+                if *b {
+                    "true".to_string()
+                } else {
+                    "false".to_string()
+                }
+            }
+            _ => {
+                violations.push(LintViolation {
+                    code: "invalid-regex-predicate".to_string(),
+                    message: format!(
+                        "{}: operator '{}' value must be a string, number, or boolean",
+                        path, op
+                    ),
+                    severity: Severity::Error,
+                });
+                continue;
+            }
+        };
+        let case_insensitive =
+            matches!(op, "iregex" | "not_iregex") || pred.case_insensitive.unwrap_or(false);
+        if let Err(err) = compile_regex_pattern(&pat, case_insensitive) {
+            violations.push(LintViolation {
+                code: "invalid-regex-predicate".to_string(),
+                message: format!(
+                    "{}: invalid {} pattern '{}': {}. Dumpling uses the Rust regex crate \
+                     (no look-around); prefer not_like / not_ilike / not_regex / not_iregex \
+                     for \"match unless …\" policies.",
+                    path, op, pat, err
+                ),
+                severity: Severity::Error,
+            });
         }
     }
 }
@@ -525,6 +626,7 @@ mod tests {
             "unsalted-hash",
             "inconsistent-domain-strategy",
             "uncovered-sensitive-column",
+            "invalid-regex-predicate",
         ];
         // Build a config that triggers all violations
         let mut cfg = empty_config();
@@ -545,6 +647,20 @@ mod tests {
         let mut sensitive = HashSet::new();
         sensitive.insert("secret".to_string());
         cfg.sensitive_columns.insert("t5".to_string(), sensitive);
+        // invalid-regex-predicate
+        cfg.row_filters.insert(
+            "t6".to_string(),
+            crate::settings::RowFilterSet {
+                retain: vec![crate::settings::Predicate {
+                    column: "email".to_string(),
+                    op: "iregex".to_string(),
+                    value: Some(serde_json::json!("^(?!andy).*")),
+                    values: None,
+                    case_insensitive: None,
+                }],
+                delete: vec![],
+            },
+        );
 
         let violations = lint_policy(&cfg);
         let found_codes: std::collections::HashSet<&str> =
@@ -552,5 +668,35 @@ mod tests {
         for code in &known_codes {
             assert!(found_codes.contains(code), "missing code: {}", code);
         }
+    }
+
+    #[test]
+    fn detects_invalid_regex_predicate_lookaround() {
+        let mut cfg = empty_config();
+        cfg.row_filters.insert(
+            "users".to_string(),
+            crate::settings::RowFilterSet {
+                retain: vec![crate::settings::Predicate {
+                    column: "email".to_string(),
+                    op: "iregex".to_string(),
+                    value: Some(serde_json::json!("^(?!staff).*")),
+                    values: None,
+                    case_insensitive: None,
+                }],
+                delete: vec![],
+            },
+        );
+        let violations = lint_policy(&cfg);
+        let regex_violations: Vec<_> = violations
+            .iter()
+            .filter(|v| v.code == "invalid-regex-predicate")
+            .collect();
+        assert_eq!(regex_violations.len(), 1);
+        assert_eq!(regex_violations[0].severity, Severity::Error);
+        assert!(
+            regex_violations[0].message.contains("look-around")
+                || regex_violations[0].message.contains("not_ilike")
+                || regex_violations[0].message.contains("invalid")
+        );
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,10 +1,43 @@
 use anyhow::Context;
+use regex::RegexBuilder;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::log_sanitize::path_basename_for_log;
+
+/// Predicate operators accepted in `row_filters` and `column_cases` `when` clauses.
+pub(crate) const KNOWN_PREDICATE_OPS: &[&str] = &[
+    "eq",
+    "neq",
+    "in",
+    "not_in",
+    "like",
+    "ilike",
+    "not_like",
+    "not_ilike",
+    "regex",
+    "iregex",
+    "not_regex",
+    "not_iregex",
+    "lt",
+    "lte",
+    "gt",
+    "gte",
+    "is_null",
+    "not_null",
+];
+
+/// Compile a Rust `regex` crate pattern (same engine used at match time).
+pub(crate) fn compile_regex_pattern(
+    pat: &str,
+    case_insensitive: bool,
+) -> Result<regex::Regex, regex::Error> {
+    let mut builder = RegexBuilder::new(pat);
+    builder.case_insensitive(case_insensitive);
+    builder.build()
+}
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RawConfig {
@@ -535,7 +568,10 @@ fn resolve(raw: RawConfig, source_path: Option<PathBuf>) -> ResolvedConfig {
         normalized_rules.insert(table_key_norm, col_map);
     }
     let mut normalized_filters: HashMap<String, RowFilterSet> = HashMap::new();
-    for (table_key, set) in row_filters.into_iter() {
+    for (table_key, mut set) in row_filters.into_iter() {
+        for pred in set.retain.iter_mut().chain(set.delete.iter_mut()) {
+            pred.op = pred.op.to_ascii_lowercase();
+        }
         normalized_filters.insert(table_key.to_lowercase(), set);
     }
     let mut normalized_cases: HashMap<String, HashMap<String, Vec<ColumnCase>>> = HashMap::new();
@@ -547,6 +583,9 @@ fn resolve(raw: RawConfig, source_path: Option<PathBuf>) -> ResolvedConfig {
                 .into_iter()
                 .map(|mut c| {
                     c.strategy.strategy = c.strategy.strategy.to_ascii_lowercase();
+                    for pred in c.when.any.iter_mut().chain(c.when.all.iter_mut()) {
+                        pred.op = pred.op.to_ascii_lowercase();
+                    }
                     c
                 })
                 .collect();
@@ -647,13 +686,96 @@ pub(crate) fn validate_raw_config(raw: &RawConfig) -> anyhow::Result<()> {
             for (idx, case_spec) in cases.iter().enumerate() {
                 let base_path = format!("column_cases.\"{}\".{}[{}].strategy", table_key, col, idx);
                 validate_anonymizer_spec(&case_spec.strategy, &base_path)?;
+                let when_path = format!("column_cases.\"{}\".{}[{}].when", table_key, col, idx);
+                validate_when_predicates(&case_spec.when, &when_path)?;
             }
+        }
+    }
+
+    for (table_key, set) in &raw.row_filters {
+        for (idx, pred) in set.retain.iter().enumerate() {
+            validate_predicate(
+                pred,
+                &format!("row_filters.\"{}\".retain[{}]", table_key, idx),
+            )?;
+        }
+        for (idx, pred) in set.delete.iter().enumerate() {
+            validate_predicate(
+                pred,
+                &format!("row_filters.\"{}\".delete[{}]", table_key, idx),
+            )?;
         }
     }
 
     validate_output_scan_config(&raw.output_scan)?;
 
     Ok(())
+}
+
+fn validate_when_predicates(when: &When, path: &str) -> anyhow::Result<()> {
+    for (idx, pred) in when.any.iter().enumerate() {
+        validate_predicate(pred, &format!("{}.any[{}]", path, idx))?;
+    }
+    for (idx, pred) in when.all.iter().enumerate() {
+        validate_predicate(pred, &format!("{}.all[{}]", path, idx))?;
+    }
+    Ok(())
+}
+
+fn validate_predicate(pred: &Predicate, path: &str) -> anyhow::Result<()> {
+    let op = pred.op.to_ascii_lowercase();
+    if !KNOWN_PREDICATE_OPS.contains(&op.as_str()) {
+        anyhow::bail!(
+            "{}.op has unknown operator '{}'; expected one of: {}",
+            path,
+            pred.op,
+            KNOWN_PREDICATE_OPS.join(", ")
+        );
+    }
+    match op.as_str() {
+        "regex" | "iregex" | "not_regex" | "not_iregex" => {
+            let Some(value) = pred.value.as_ref() else {
+                anyhow::bail!("{}.value is required for operator '{}'", path, op);
+            };
+            let Some(pat) = predicate_value_as_pattern_string(value) else {
+                anyhow::bail!(
+                    "{}.value must be a string, number, or boolean for operator '{}'",
+                    path,
+                    op
+                );
+            };
+            let case_insensitive = matches!(op.as_str(), "iregex" | "not_iregex")
+                || pred.case_insensitive.unwrap_or(false);
+            if let Err(err) = compile_regex_pattern(&pat, case_insensitive) {
+                anyhow::bail!(
+                    "{}.value has invalid {} pattern '{}': {}. \
+                     Dumpling uses the Rust `regex` crate (https://docs.rs/regex/), which does not \
+                     support look-around ((?!…)/(?=…)/(?<!…)/(?<=…)), backreferences, or possessive \
+                     quantifiers. For \"match unless …\" policies, use not_like, not_ilike, \
+                     not_regex, or not_iregex instead of negative lookahead.",
+                    path,
+                    op,
+                    pat,
+                    err
+                );
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn predicate_value_as_pattern_string(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::Bool(b) => Some(if *b {
+            "true".to_string()
+        } else {
+            "false".to_string()
+        }),
+        _ => None,
+    }
 }
 
 fn validate_output_scan_config(cfg: &OutputScanConfig) -> anyhow::Result<()> {
@@ -1179,15 +1301,21 @@ pub struct Predicate {
     /// - dot notation: "payload.profile.tier"
     /// - Django-style notation: "payload__profile__tier"
     pub column: String,
-    /// One of: eq, neq, in, not_in, like, ilike, regex, iregex, lt, lte, gt, gte, is_null, not_null
+    /// One of: eq, neq, in, not_in, like, ilike, not_like, not_ilike, regex, iregex,
+    /// not_regex, not_iregex, lt, lte, gt, gte, is_null, not_null.
+    ///
+    /// `regex` / `iregex` / `not_regex` / `not_iregex` use the Rust [`regex`](https://docs.rs/regex/)
+    /// crate (not PCRE). Look-around, backreferences, and possessive quantifiers are unsupported
+    /// and rejected at config load. Prefer `not_like` / `not_ilike` / `not_regex` / `not_iregex`
+    /// for “match unless …” policies instead of negative lookahead.
     pub op: String,
-    /// Single value for eq/neq/like/ilike/lt/lte/gt/gte
+    /// Single value for eq/neq/like/ilike/not_like/not_ilike/regex/iregex/not_regex/not_iregex/lt/lte/gt/gte
     #[serde(default)]
     pub value: Option<serde_json::Value>,
     /// Multiple values for in/not_in
     #[serde(default)]
     pub values: Option<Vec<serde_json::Value>>,
-    /// Case-insensitive match for eq/neq/contains/starts_with/ends_with/like (overridden by ilike)
+    /// Case-insensitive match for eq/neq/like/not_like (overridden by ilike/not_ilike/iregex/not_iregex)
     #[serde(default)]
     pub case_insensitive: Option<bool>,
 }
@@ -1971,6 +2099,73 @@ salt = "testsalt"
             .get("payload.shipTo.fullName")
             .expect("expected camelCase path segments in resolved map key");
         assert_eq!(spec.strategy, "redact");
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn invalid_regex_predicate_fails_validation() {
+        let path = write_temp_config(
+            r#"
+[row_filters."public.users"]
+retain = [{ column = "email", op = "iregex", value = "(unterminated" }]
+"#,
+        );
+        let err = load_config(Some(&path), false).expect_err("expected invalid regex to fail load");
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("row_filters.\"public.users\".retain[0]"));
+        assert!(msg.contains("invalid iregex pattern"));
+        assert!(msg.contains("Rust `regex` crate") || msg.contains("look-around"));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn lookaround_regex_predicate_fails_validation() {
+        let path = write_temp_config(
+            r#"
+[[column_cases."public.users".email]]
+when.all = [{ column = "email", op = "iregex", value = "^(?!andy).*" }]
+strategy = { strategy = "blank" }
+"#,
+        );
+        let err =
+            load_config(Some(&path), false).expect_err("expected lookaround regex to fail load");
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("column_cases.\"public.users\".email[0].when.all[0]"));
+        assert!(msg.contains("invalid iregex pattern"));
+        assert!(msg.contains("not_ilike") || msg.contains("not_iregex"));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn unknown_predicate_op_fails_validation() {
+        let path = write_temp_config(
+            r#"
+[row_filters."public.users"]
+delete = [{ column = "email", op = "contains", value = "@" }]
+"#,
+        );
+        let err =
+            load_config(Some(&path), false).expect_err("expected unknown predicate op to fail");
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("unknown operator 'contains'"));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn valid_regex_and_not_ilike_predicates_load() {
+        let path = write_temp_config(
+            r#"
+[row_filters."public.users"]
+retain = [
+  { column = "email", op = "iregex", value = ".*@example\\.com$" },
+  { column = "email", op = "not_ilike", value = "%@staff.example.com" },
+]
+"#,
+        );
+        let cfg = load_config(Some(&path), false).expect("valid predicates should load");
+        let set = cfg.row_filters.get("public.users").expect("filters");
+        assert_eq!(set.retain.len(), 2);
+        assert_eq!(set.retain[1].op, "not_ilike");
         let _ = fs::remove_file(path);
     }
 }

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -3130,6 +3130,96 @@ COPY public.users (id, email) FROM stdin;
     }
 
     #[test]
+    fn column_cases_not_ilike_scrubs_unless_staff_domain() {
+        // Issue #79: "scrub unless staff" without lookaround — blank non-staff emails.
+        let blank = AnonymizerSpec {
+            strategy: "blank".to_string(),
+            salt: None,
+            min: None,
+            max: None,
+            scale: None,
+            length: None,
+            min_days: None,
+            max_days: None,
+            min_seconds: None,
+            max_seconds: None,
+            domain: None,
+            unique_within_domain: None,
+            as_string: None,
+            locale: None,
+            faker: None,
+            format: None,
+        };
+        let email_cases = vec![ColumnCase {
+            when: When {
+                any: vec![],
+                all: vec![
+                    crate::settings::Predicate {
+                        column: "email".into(),
+                        op: "not_ilike".into(),
+                        value: Some(serde_json::json!("%@wearecrew.com")),
+                        values: None,
+                        case_insensitive: None,
+                    },
+                    crate::settings::Predicate {
+                        column: "email".into(),
+                        op: "not_ilike".into(),
+                        value: Some(serde_json::json!("%@reskinned.clothing")),
+                        values: None,
+                        case_insensitive: None,
+                    },
+                ],
+            },
+            strategy: blank,
+        }];
+        let mut per_col: HashMap<String, Vec<ColumnCase>> = HashMap::new();
+        per_col.insert("email".into(), email_cases);
+        let mut column_cases = HashMap::new();
+        column_cases.insert("public.reskinned_inventory_user".into(), per_col);
+
+        let cfg = ResolvedConfig {
+            salt: None,
+            rules: HashMap::new(),
+            row_filters: HashMap::new(),
+            column_cases,
+            sensitive_columns: HashMap::new(),
+            output_scan: crate::settings::OutputScanConfig::default(),
+            pg_restore: crate::settings::PgRestoreConfig::default(),
+            keep_original: None,
+            source_path: None,
+        };
+        let reg = AnonymizerRegistry::from_config(&cfg);
+        let mut proc = SqlStreamProcessor::new(reg, cfg, None, DumpFormat::Postgres);
+        let input = r#"
+COPY public.reskinned_inventory_user (id, email, first_name, password) FROM stdin;
+1	andy@wearecrew.com	Andy	pbkdf2_old
+2	ops@reskinned.clothing	Ops	pbkdf2_old
+3	buyer@gmail.com	Buyer	pbkdf2_old
+\.
+"#;
+        let mut reader = std::io::BufReader::new(input.as_bytes());
+        let mut out = Vec::new();
+        proc.process(&mut reader, &mut out).unwrap();
+        let s = String::from_utf8(out).unwrap();
+        assert!(
+            s.contains("andy@wearecrew.com"),
+            "staff wearecrew email should pass through: {s}"
+        );
+        assert!(
+            s.contains("ops@reskinned.clothing"),
+            "staff reskinned email should pass through: {s}"
+        );
+        assert!(
+            !s.contains("buyer@gmail.com"),
+            "non-staff email should be blanked: {s}"
+        );
+        assert!(
+            s.contains("3\t\tBuyer\t"),
+            "buyer email cell should be empty string: {s}"
+        );
+    }
+
+    #[test]
     fn deterministic_domain_mapping_is_consistent_across_tables() {
         let mut rules: HashMap<String, HashMap<String, AnonymizerSpec>> = HashMap::new();
         let email_spec = AnonymizerSpec {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#79](https://github.com/ababic/dumpling/issues/79): `regex` / `iregex` predicates previously failed open — invalid or unsupported patterns (including lookaround) compiled to a never-match regex (`$^`), so configs appeared to work while matching nothing.

Rebased onto latest `main` (includes `keep` strategy from #77/#78 and docs from #82). Conflict in `src/sql.rs` resolved by keeping both the `keep` pipeline test and the new `not_ilike` scrub-unless-staff test.

### Changes
- **Fail closed at config load**: compile every `regex` / `iregex` / `not_regex` / `not_iregex` pattern during validation; reject unknown predicate ops.
- **Remove silent `$^` fallback** in the runtime regex cache (panic if an unvalidated pattern somehow slips through).
- **New negation ops**: `not_like`, `not_ilike`, `not_regex`, `not_iregex` so “match unless …” policies don’t need lookaround.
- **`lint-policy`**: compile-check the same patterns (`invalid-regex-predicate`); invalid configs also fail before lint because load validation rejects them.
- **Docs**: README documents the Rust `regex` crate (not PCRE), lookaround limits, and points at `keep` / `not_ilike` alternatives.

### Tests
- Config load rejects unterminated and lookaround patterns with actionable errors.
- Filter + SQL pipeline tests for `not_ilike` / `not_iregex` scrub-unless-staff behavior (issue repro dump).
- Existing `keep` staff-email pipeline test retained after rebase.
- Lint catalog includes `invalid-regex-predicate`.

### CI
`cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, and `cargo test --all-targets --all-features` (161 passed) all pass locally after rebase.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-740bb389-b0e8-4d9a-9c8a-eeabb4481aeb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-740bb389-b0e8-4d9a-9c8a-eeabb4481aeb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

