### PR TITLE
Document keep-by-omission for column_cases without default rules (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ These keys are valid on **multiple** strategies (unless validation says otherwis
 
 ## Conditional per-column cases
 
-Define default strategies in `rules."<table>"` and add ordered per-column cases in `column_cases."<table>"."<column>"`. For each row and column, Dumpling applies the first matching case; if none match, it falls back to the default from `rules`.
+Define default strategies in `rules."<table>"` and add ordered per-column cases in `column_cases."<table>"."<column>"`. For each row and column, Dumpling applies the first matching case; if none match, it falls back to the default from `rules` (when present).
 
 ```toml
 [rules."public.users"]
@@ -251,7 +251,23 @@ when.any = [{ column = "country", op = "in", values = ["DE","FR","GB"] }]
 strategy = { strategy = "hash", salt = "eu-salt", as_string = true }
 ```
 
-To **retain** some values while scrubbing the rest, put the scrubbing strategy in `[rules]` and add a first-match `keep` case:
+### Selection semantics
+
+For each cell (INSERT or COPY):
+
+1. Evaluate `column_cases` for that table+column in declaration order; **first matching `when` wins** (no merge or fallthrough).
+2. If no case matches and a `[rules."<table>".column]` entry exists, apply that default strategy.
+3. If no case matches and there is **no** default `rules` entry (and no JSON path rules for the column), the cell is **left unchanged** (passthrough of the original SQL literal / COPY field, including `NULL` / `\N`).
+
+In other words: missing strategy selection is always keep-by-omission. That is intentional and supported—not an accident.
+
+- `when.any` is OR, `when.all` is AND; you can use either or both. If both are empty, the case matches unconditionally.
+- Row filtering (`row_filters`) is evaluated before cases; deleted rows are not transformed.
+- For `--strict-coverage` / `[sensitive_columns]`, a column is **covered** if it has a `rules` entry **or** at least one `column_cases` entry (cases-only still counts as an explicit policy).
+
+### Cookbook: default scrub + keep exceptions
+
+To **retain** some values while scrubbing the rest, put the scrubbing strategy in `[rules]` and add a first-match `keep` case (preferred when the allowlist is small and easy to express positively):
 
 ```toml
 [rules."public.reskinned_inventory_user"]
@@ -265,9 +281,21 @@ when.any = [
 strategy = { strategy = "keep" }
 ```
 
-- `when.any` is OR, `when.all` is AND; you can use either or both. If both are empty, the case matches unconditionally.
-- First-match-wins per column; there is no merge or fallthrough.
-- Row filtering (`row_filters`) is evaluated before cases; deleted rows are not transformed.
+### Cookbook: scrub matching rows only (keep the rest)
+
+When you want to anonymize **some** rows and leave others intact, omit the default `rules` entry and scrub only via matching cases. Non-matching rows keep their original values (keep-by-omission):
+
+```toml
+# No [rules."public.users".email] — non-matching rows keep the original email.
+[[column_cases."public.users".email]]
+when.any = [
+  { column = "email", op = "ilike", value = "%@example.com" },
+  { column = "email", op = "ilike", value = "%@gmail.com" },
+]
+strategy = { strategy = "email", domain = "user_email", unique_within_domain = true, as_string = true }
+```
+
+Prefer positive `when` predicates (`ilike`, `in`, …) for the rows you want scrubbed; inverting “unless domain X” with `iregex` lookaround is not supported by Rust’s `regex` crate. When the allowlist is easier to express than the scrub set, use the `keep` cookbook above instead.
 
 ---
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -170,6 +170,8 @@ Dumpling only exposes a **subset** wired in `src/faker_dispatch.rs`; unsupported
 
 Strategy names and **per-strategy options** (`min`, `scale`, `as_string`, `faker`, …) are documented in the repository **README** under **Anonymization strategies** (each strategy lists only the keys it accepts, plus **Choosing a strategy** for when to prefer cheap vs realistic transforms, and **Cross-cutting options** for `domain`, `unique_within_domain`, and `as_string`). Row filters, JSON path rules, and conditional `column_cases` are also covered in the README before the full TOML example.
 
+**`column_cases` keep-by-omission:** if a column has only `[[column_cases.…]]` entries and **no** matching case (and no default `[rules]` entry / JSON path rules), the cell is left unchanged. That pattern is **supported** for selective anonymization (scrub matching rows; keep the rest). For the inverse shape (default scrub + allowlist exceptions), use the explicit `keep` strategy under `column_cases`. See the README section *Conditional per-column cases* for selection semantics and both cookbook examples.
+
 The sections below expand on **JSON path rules** (same semantics as the README) and **secret references** in more depth.
 
 ## Baseline config template

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -2773,6 +2773,85 @@ COPY public.events (id, email, the_date) FROM stdin;
     }
 
     #[test]
+    fn column_cases_without_default_rule_keep_non_matching_cells() {
+        // Cases-only policy: scrub matching rows; omit [rules] so non-matching cells passthrough.
+        let mut column_cases: HashMap<String, HashMap<String, Vec<ColumnCase>>> = HashMap::new();
+        let email_cases = vec![ColumnCase {
+            when: When {
+                any: vec![crate::settings::Predicate {
+                    column: "email".into(),
+                    op: "ilike".into(),
+                    value: Some(serde_json::json!("%@example.com")),
+                    values: None,
+                    case_insensitive: None,
+                }],
+                all: vec![],
+            },
+            strategy: base_spec("redact", Some(true)),
+        }];
+        let mut per_col: HashMap<String, Vec<ColumnCase>> = HashMap::new();
+        per_col.insert("email".into(), email_cases);
+        column_cases.insert("public.users".into(), per_col);
+
+        let mut sensitive_columns: HashMap<String, HashSet<String>> = HashMap::new();
+        sensitive_columns.insert("public.users".into(), HashSet::from(["email".into()]));
+
+        let cfg = ResolvedConfig {
+            salt: None,
+            rules: HashMap::new(),
+            row_filters: HashMap::new(),
+            column_cases,
+            sensitive_columns,
+            output_scan: crate::settings::OutputScanConfig::default(),
+            pg_restore: crate::settings::PgRestoreConfig::default(),
+            keep_original: None,
+            source_path: None,
+        };
+        assert!(
+            is_explicitly_covered_column(&cfg, Some("public"), "users", "email"),
+            "cases-only columns count as covered for strict coverage"
+        );
+
+        let reg = AnonymizerRegistry::from_config(&cfg);
+        set_random_seed(1);
+        let mut proc = SqlStreamProcessor::new(reg, cfg, None, DumpFormat::Postgres);
+        let input = r#"
+CREATE TABLE public.users (id int, email text);
+INSERT INTO public.users (id, email) VALUES
+  (1, 'staff@myco.com'),
+  (2, 'bob@example.com');
+COPY public.users (id, email) FROM stdin;
+3	alice@myco.com
+4	eve@example.com
+\.
+"#;
+        let mut reader = std::io::BufReader::new(input.as_bytes());
+        let mut out = Vec::new();
+        proc.process(&mut reader, &mut out).unwrap();
+        let s = String::from_utf8(out).unwrap();
+
+        // Non-matching rows: original emails preserved (INSERT + COPY).
+        assert!(
+            s.contains("'staff@myco.com'"),
+            "INSERT keep-by-omission failed:\n{s}"
+        );
+        assert!(
+            s.contains("\n3\talice@myco.com\n"),
+            "COPY keep-by-omission failed:\n{s}"
+        );
+        // Matching rows: scrubbed.
+        assert!(
+            !s.contains("bob@example.com"),
+            "INSERT case should scrub:\n{s}"
+        );
+        assert!(
+            !s.contains("eve@example.com"),
+            "COPY case should scrub:\n{s}"
+        );
+        assert!(s.contains("REDACTED"), "expected redact replacement:\n{s}");
+    }
+
+    #[test]
     fn column_cases_first_match_wins() {
         // Base: email -> hash
         let mut rules: HashMap<String, HashMap<String, AnonymizerSpec>> = HashMap::new();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #80.

Documents the intended semantics for selective anonymization when a column has `[[column_cases.…]]` but no default `[rules]` entry:

1. No matching case and no default rule → cell left unchanged (passthrough).
2. Default `rules` strategy still applies when no case matches (unchanged).
3. Cases-only is a **supported** pattern for “scrub matching rows; keep the rest,” with a cookbook example.

Also documents how this coexists with the explicit `keep` strategy from #77/#78 (preferred for “default scrub + allowlist exceptions”).

Rebased onto latest `main` (`bbd2ddf`); README conflict resolved by keeping both cookbooks.

## Changes

- `README.md` — selection semantics + two cookbooks (`keep` exceptions vs cases-only keep-by-omission)
- `docs/src/configuration.md` — brief pointer covering both patterns
- `src/sql.rs` — regression test for INSERT/COPY keep-by-omission and coverage

## Test plan

- [x] Rebased onto `origin/main`; conflict in `README.md` resolved
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test … column_cases_` (4 passed, including keep + keep-by-omission)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fd42df3-3a9e-46d2-8a66-51e742ab006d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fd42df3-3a9e-46d2-8a66-51e742ab006d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

