### PR TITLE
Expand --report JSON into a compliance audit sidecar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ src/
                    CREATE TABLE length extraction, sensitive coverage tracking
   filter.rs      — Row-filter predicate evaluation (eq/neq/like/regex/JSON-path/…)
   scan.rs        — Post-transform residual PII scanner (email/SSN/PAN/token regex)
-  report.rs      — JSON report data structures and Reporter helper
+  report.rs      — JSON report / audit sidecar: provenance, streaming checksums, Reporter helper
   compressed_input.rs — gzip/ZIP wrappers; streaming vs temp materialization
   dump_input_resolve.rs — shared `--input` file resolution for anonymize + scaffold-config
   dump_input_detect.rs — PGDMP / directory dumps / MSSQL sniff helpers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Added
 
 - **JSON `--report` audit sidecar**: Dumpling version, per-run id and timestamp, config path + SHA-256, streaming input/output SHA-256, dump-seal digest cross-link (`seal_sha256`), explicit gate flags, and coverage/scan outcomes. `run_id` / `started_at` are instance metadata; policy fingerprint fields stay deterministic across re-runs ([#13](https://github.com/ababic/dumpling/issues/13)).
+- **`--no-seal`**: skip writing the dump-seal SQL comment (stdin/stdout pipelines). Incoming seals are still recognized; `--report` still records `seal_sha256`.
+
+### Docs
+
+- `--help` Examples plus long help for `--report` / `--no-seal`. mdBook and README cover dump seals, the JSON sidecar fields, and how to verify `seal_sha256` with or without a seal line.
 
 ## [0.7.0] - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- **JSON `--report` audit sidecar**: Dumpling version, per-run id and timestamp, config path + SHA-256, streaming input/output SHA-256, dump-seal digest cross-link (`seal_sha256`), explicit gate flags, and coverage/scan outcomes. `run_id` / `started_at` are instance metadata; policy fingerprint fields stay deterministic across re-runs ([#13](https://github.com/ababic/dumpling/issues/13)).
+
 ## [0.7.0] - 2026-07-03
 
 Stable **0.7.0** release (supersedes **0.7.0-alpha** and **0.7.0-beta** prereleases).

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ cat dump.sql | dumpling > sanitized.sql         # stream from stdin to stdout
 dumpling -i dump.sql -c .dumplingconf           # use explicit config path
 dumpling --check -i dump.sql                    # exit 1 if changes would occur, no output
 dumpling --stats -i dump.sql -o out.sql         # print summary to stderr
-dumpling --report report.json -i dump.sql       # write detailed JSON report of changes/drops
+dumpling --report report.json -i dump.sql       # write JSON audit sidecar (provenance, checksums, coverage)
 dumpling --strict-coverage --report report.json -i dump.sql --check  # fail on uncovered sensitive columns
 dumpling --scan-output --report report.json -i dump.sql               # scan transformed output for residual PII-like patterns
 dumpling --scan-output --fail-on-findings --report report.json -i dump.sql --check  # fail if scan thresholds are exceeded
@@ -482,11 +482,20 @@ A column is considered **covered** only when it has an explicit `rules` entry or
 
 When `--report <file>` is used, the JSON output includes:
 
+- `dumpling_version`, `run_id`, `started_at` (run identity; `run_id` / `started_at` differ on every invocation)
+- `config_source` and `config_sha256` (SHA-256 of the loaded config file bytes)
+- `input_sha256` / `output_sha256` (SHA-256 of the SQL streams Dumpling actually read/wrote; `output_sha256` is omitted in `--check`)
+- `seal_sha256` (same digest as the dump-seal `sha256=` field — cross-link the sidecar to the dump)
+- `flags` (gate flags such as `strict_coverage`, `fail_on_findings`, `check`) and `outcomes` (coverage/scan pass/fail, trusted passthrough)
 - `sensitive_columns_detected`
 - `sensitive_columns_covered`
 - `sensitive_columns_uncovered`
 - `deterministic_mapping_domains` (columns configured with deterministic domain mapping)
 - `output_scan` (when `--scan-output` is enabled), including category counts and sample locations
+
+`run_id` and `started_at` are **instance** metadata. Policy fingerprint fields (`seal_sha256`, `config_sha256`, `dumpling_version`) stay the same across deterministic re-runs with the same config, version, and transform-affecting options.
+
+See [CI guardrails](docs/src/ci-guardrails.md#audit-evidence) for an audit-evidence example that checks `report.json` against the dump seal.
 
 ### CI gate pattern
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Follow these steps once; you will have a working path from “raw dump” to “
 1. **Generate a draft policy (recommended)** — Run `dumpling scaffold-config -i dump.sql -o .dumplingconf` to emit a **beta** starter TOML with inferred `[rules]` from column names in `CREATE TABLE`, `INSERT`, and (PostgreSQL) `COPY` headers. Heuristics are **English-oriented**; treat the file as **draft only**—review every rule before production or compliance workflows. Add a global `salt` (for example `salt = "${DUMPLING_SALT}"`) and resolve `${…}` references before anonymizing. Optionally pass **`--infer-json-paths`** to sample up to **five rows per table** (reservoir) and suggest nested JSON keys as `column.path.to.leaf`; use **`--max-json-depth`** if you need a different walk depth (default 24). For PostgreSQL **custom-format** or **directory-format** archives, pass **`--input`** pointing at the archive with **`--format postgres`** (default); Dumpling auto-detects and runs **`pg_restore`** (optional **`--pg-restore-path`** / **`--pg-restore-arg`**). See `dumpling scaffold-config --help`.
 2. **Or start from the example policy** — Copy [`.dumplingconf.example`](.dumplingconf.example) to `.dumplingconf` (or merge under `[tool.dumpling]` in `pyproject.toml`) and edit `[rules]` by hand. Set environment variables for `salt` and any `${…}` references so Dumpling can resolve secrets at startup.
 3. **Align rules with your dump** — If you did not use `scaffold-config`, open the dump beside the config: `CREATE TABLE`, `COPY … (…)`, and `INSERT INTO … (…)` lines list identifiers for `[rules."table"]` or `[rules."schema.table"]` (see [Configuration (TOML)](#configuration-toml)). Trim rules to the tables you care about first, then extend columns and strategies as you go.
-4. **Run Dumpling** — `dumpling -i dump.sql -o sanitized.sql` (add `-c path` if the config is not in the default search path). Use `dumpling --check -i dump.sql` when you only want to know whether anything would change.
+4. **Run Dumpling** — `dumpling -i dump.sql -o sanitized.sql` (add `-c path` if the config is not in the default search path). Use `dumpling --check -i dump.sql` when you only want to know whether anything would change. Pass **`--no-seal`** to skip the dump-seal comment on streaming output, and **`--report file.json`** for an audit sidecar.
 5. **Tighten the policy** — Run `dumpling lint-policy` on your config. When you are ready for stricter gates, add `[sensitive_columns]` and use `--strict-coverage` / `--report` / `--scan-output` as described under [Usage](#usage).
 
 The same flow is spelled out in the docs: [Getting started](https://ababic.github.io/dumpling/getting-started.html).
@@ -100,6 +100,7 @@ dumpling -i dump.sql -c .dumplingconf           # use explicit config path
 dumpling --check -i dump.sql                    # exit 1 if changes would occur, no output
 dumpling --stats -i dump.sql -o out.sql         # print summary to stderr
 dumpling --report report.json -i dump.sql       # write JSON audit sidecar (provenance, checksums, coverage)
+cat dump.sql | dumpling --no-seal --report report.json > sanitized.sql  # stream without a dump-seal comment
 dumpling --strict-coverage --report report.json -i dump.sql --check  # fail on uncovered sensitive columns
 dumpling --scan-output --report report.json -i dump.sql               # scan transformed output for residual PII-like patterns
 dumpling --scan-output --fail-on-findings --report report.json -i dump.sql --check  # fail if scan thresholds are exceeded
@@ -123,7 +124,7 @@ If no configuration is found, Dumpling fails closed by default and exits non-zer
 The error output lists every checked location. Use `--allow-noop` to explicitly
 permit no-op behavior.
 
-The **dump seal** comment prefixed to successful output and **`--security-profile hardened`** are documented in the [configuration guide](https://ababic.github.io/dumpling/configuration.html) (see *Dump seal* and *Hardened security profile*).
+The **dump seal** comment prefixed to successful output (opt out with **`--no-seal`**) and **`--security-profile hardened`** are documented in the [configuration guide](https://ababic.github.io/dumpling/configuration.html) (see *Dump seal*, *JSON report*, and *Hardened security profile*). `--report` always records `seal_sha256` even when `--no-seal` is set.
 
 ---
 
@@ -485,8 +486,8 @@ When `--report <file>` is used, the JSON output includes:
 - `dumpling_version`, `run_id`, `started_at` (run identity; `run_id` / `started_at` differ on every invocation)
 - `config_source` and `config_sha256` (SHA-256 of the loaded config file bytes)
 - `input_sha256` / `output_sha256` (SHA-256 of the SQL streams Dumpling actually read/wrote; `output_sha256` is omitted in `--check`)
-- `seal_sha256` (same digest as the dump-seal `sha256=` field — cross-link the sidecar to the dump)
-- `flags` (gate flags such as `strict_coverage`, `fail_on_findings`, `check`) and `outcomes` (coverage/scan pass/fail, trusted passthrough)
+- `seal_sha256` (same digest as a dump-seal `sha256=` field; still present with `--no-seal`)
+- `flags` (`strict_coverage`, `fail_on_findings`, `check`, `no_seal`, …) and `outcomes` (coverage/scan pass/fail, trusted passthrough)
 - `sensitive_columns_detected`
 - `sensitive_columns_covered`
 - `sensitive_columns_uncovered`
@@ -495,7 +496,7 @@ When `--report <file>` is used, the JSON output includes:
 
 `run_id` and `started_at` are **instance** metadata. Policy fingerprint fields (`seal_sha256`, `config_sha256`, `dumpling_version`) stay the same across deterministic re-runs with the same config, version, and transform-affecting options.
 
-See [CI guardrails](docs/src/ci-guardrails.md#audit-evidence) for an audit-evidence example that checks `report.json` against the dump seal.
+See the [configuration guide](docs/src/configuration.md#json-report-audit-sidecar) and [CI guardrails](docs/src/ci-guardrails.md#audit-evidence) for field notes and how to verify `report.json` against a dump seal (or against `seal_sha256` alone when using `--no-seal`).
 
 ### CI gate pattern
 

--- a/docs/src/ci-guardrails.md
+++ b/docs/src/ci-guardrails.md
@@ -139,6 +139,47 @@ CI artifact on your main branch and compare against it in PRs:
 
 ---
 
+## Audit evidence
+
+Keep `report.json` next to the sanitized dump. Together they answer what policy and Dumpling version transformed which input, without reconstructing the run from CI logs.
+
+The dump seal (first line of the SQL output) and the JSON sidecar share the same digest:
+
+```bash
+SEAL=$(sed -n '1s/.*sha256=//p' sanitized.sql | tr -d '[:space:]')
+REPORT=$(jq -r '.seal_sha256' report.json)
+test -n "$SEAL" && test "$SEAL" = "$REPORT"
+```
+
+Useful fields for a compliance review:
+
+| Field | Stable across re-runs? | Meaning |
+|---|---|---|
+| `dumpling_version` | yes (same binary) | Crate semver that produced the dump |
+| `seal_sha256` | yes (same policy + transform options) | Same value as dump-seal `sha256=` |
+| `config_source` / `config_sha256` | yes (unchanged file) | Path and SHA-256 of the loaded config bytes |
+| `input_sha256` / `output_sha256` | yes (same streams) | SHA-256 of the SQL Dumpling read/wrote (`output_sha256` omitted for `--check`) |
+| `flags` / `outcomes` | yes (same CLI) | Gate flags (`strict_coverage`, `fail_on_findings`, …) and pass/fail |
+| `run_id` / `started_at` | **no** | Per-invocation identity (RFC 3339 UTC) |
+
+`input_sha256` is over the SQL byte stream Dumpling actually processed (decoded `pg_restore` output, decompressed gzip, and so on), not necessarily the raw archive file on disk.
+
+Example production invocation:
+
+```bash
+dumpling \
+  --strict-coverage \
+  --scan-output \
+  --fail-on-findings \
+  --report report.json \
+  -i dump.sql \
+  -o sanitized.sql
+```
+
+Archive both `sanitized.sql` and `report.json`. To confirm a later re-run used the same policy, compare `seal_sha256` (and `config_sha256`); do not expect `run_id` or `started_at` to match.
+
+---
+
 ## Tips
 
 - Run `dumpling lint-policy` locally before opening a PR to catch violations

--- a/docs/src/ci-guardrails.md
+++ b/docs/src/ci-guardrails.md
@@ -141,9 +141,9 @@ CI artifact on your main branch and compare against it in PRs:
 
 ## Audit evidence
 
-Keep `report.json` next to the sanitized dump. Together they answer what policy and Dumpling version transformed which input, without reconstructing the run from CI logs.
+Keep `report.json` next to the sanitized dump (or keep the report alone when using `--no-seal`). Together they answer what policy and Dumpling version transformed which input, without reconstructing the run from CI logs.
 
-The dump seal (first line of the SQL output) and the JSON sidecar share the same digest:
+**Default (seal on the dump).** The first line of the SQL output and `seal_sha256` in the sidecar share the same digest:
 
 ```bash
 SEAL=$(sed -n '1s/.*sha256=//p' sanitized.sql | tr -d '[:space:]')
@@ -151,20 +151,26 @@ REPORT=$(jq -r '.seal_sha256' report.json)
 test -n "$SEAL" && test "$SEAL" = "$REPORT"
 ```
 
+**`--no-seal` (streaming / no comment on the SQL).** There is no seal line to grep. Confirm the sidecar still has a 64-character digest and that `flags.no_seal` is true:
+
+```bash
+jq -e '.flags.no_seal == true and (.seal_sha256 | length == 64)' report.json
+```
+
 Useful fields for a compliance review:
 
 | Field | Stable across re-runs? | Meaning |
 |---|---|---|
 | `dumpling_version` | yes (same binary) | Crate semver that produced the dump |
-| `seal_sha256` | yes (same policy + transform options) | Same value as dump-seal `sha256=` |
+| `seal_sha256` | yes (same policy + transform options) | Same value as dump-seal `sha256=` (recorded even with `--no-seal`) |
 | `config_source` / `config_sha256` | yes (unchanged file) | Path and SHA-256 of the loaded config bytes |
 | `input_sha256` / `output_sha256` | yes (same streams) | SHA-256 of the SQL Dumpling read/wrote (`output_sha256` omitted for `--check`) |
-| `flags` / `outcomes` | yes (same CLI) | Gate flags (`strict_coverage`, `fail_on_findings`, …) and pass/fail |
+| `flags` / `outcomes` | yes (same CLI / result) | Gate flags (`strict_coverage`, `fail_on_findings`, `no_seal`, …) and pass/fail |
 | `run_id` / `started_at` | **no** | Per-invocation identity (RFC 3339 UTC) |
 
 `input_sha256` is over the SQL byte stream Dumpling actually processed (decoded `pg_restore` output, decompressed gzip, and so on), not necessarily the raw archive file on disk.
 
-Example production invocation:
+Example production invocation (file output with dump seal):
 
 ```bash
 dumpling \
@@ -176,7 +182,13 @@ dumpling \
   -o sanitized.sql
 ```
 
-Archive both `sanitized.sql` and `report.json`. To confirm a later re-run used the same policy, compare `seal_sha256` (and `config_sha256`); do not expect `run_id` or `started_at` to match.
+Streaming without a dump-seal comment:
+
+```bash
+cat dump.sql | dumpling --no-seal --report report.json > sanitized.sql
+```
+
+Archive `report.json` with the sanitized SQL. To confirm a later re-run used the same policy, compare `seal_sha256` (and `config_sha256`); do not expect `run_id` or `started_at` to match. Full field notes: [JSON report (audit sidecar)](configuration.md#json-report-audit-sidecar).
 
 ---
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -95,7 +95,7 @@ Every successful run that writes output prefixes the stream with a single-line S
 
 The `sha256` is over canonical JSON that includes the Dumpling version, the active security profile, a stable encoding of the resolved policy (rules, row filters, column cases, sensitive columns, output scan, global salt), and **runtime options** that affect transforms: `--format` and the effective `--seed` / `DUMPLING_SEED` value in standard profile (`null` in hardened, where seeds are ignored).
 
-If the **input** already begins with a seal line and it **matches** the current run, Dumpling copies the rest of the file through unchanged. If the line looks like a seal but does **not** match (stale policy, different flags, or older `v=`), that line is **dropped** and the dump is re-processed so you do not end up with two seal lines. `--strict-coverage` cannot be combined with a matching seal (table definitions are not scanned in passthrough mode). `--check` writes no output and therefore emits no seal line.
+If the **input** already begins with a seal line and it **matches** the current run, Dumpling copies the rest of the file through unchanged. If the line looks like a seal but does **not** match (stale policy, different flags, or older `v=`), that line is **dropped** and the dump is re-processed so you do not end up with two seal lines. `--strict-coverage` cannot be combined with a matching seal (table definitions are not scanned in passthrough mode). `--check` writes no output and therefore emits no seal line. When `--report` is set, the JSON sidecar records the same digest as `seal_sha256` so reviewers can cross-link dump and report (see [Audit evidence](ci-guardrails.md#audit-evidence)).
 
 ## Hardened security profile
 
@@ -146,13 +146,14 @@ dumpling --security-profile hardened -i dump.sql -o sanitized.sql
 
 ### Report metadata
 
-The JSON report always includes the active security profile:
+The JSON report always includes the active security profile, plus audit provenance when `--report` is used (`dumpling_version`, `seal_sha256`, config/input/output checksums, gate flags). See [Audit evidence](ci-guardrails.md#audit-evidence).
 
 ```json
 {
+  "dumpling_version": "0.7.0",
   "security_profile": "hardened",
-  "total_rows_processed": 1000,
-  ...
+  "seal_sha256": "…",
+  "total_rows_processed": 1000
 }
 ```
 
@@ -362,6 +363,8 @@ When `--report` is enabled, coverage fields are added to JSON output:
 - `sensitive_columns_detected`
 - `sensitive_columns_covered`
 - `sensitive_columns_uncovered`
+
+The same JSON file is also the **audit sidecar**: it records Dumpling version, config path + checksum, streaming I/O checksums, the dump-seal digest (`seal_sha256`, matching `sha256=` on the output), gate flags, and coverage/scan outcomes. `run_id` and `started_at` are per-invocation and will not match on re-runs; fingerprint fields are deterministic. See [Audit evidence](ci-guardrails.md#audit-evidence).`
 
 Example CI gate:
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -87,15 +87,47 @@ run, pass `--allow-noop`.
 
 ---
 
-## Dump seal (always on)
+## Dump seal (on by default)
 
-Every successful run that writes output prefixes the stream with a single-line SQL comment:
+Successful runs that **write** output prefix the stream with one SQL comment:
 
-`-- dumpling-seal: v=3 version=<semver> profile=<standard|hardened> sha256=<64 hex chars>`
+```text
+-- dumpling-seal: v=3 version=<semver> profile=<standard|hardened> sha256=<64 hex chars>
+```
 
-The `sha256` is over canonical JSON that includes the Dumpling version, the active security profile, a stable encoding of the resolved policy (rules, row filters, column cases, sensitive columns, output scan, global salt), and **runtime options** that affect transforms: `--format` and the effective `--seed` / `DUMPLING_SEED` value in standard profile (`null` in hardened, where seeds are ignored).
+The `sha256` fingerprints Dumpling version, the active security profile, a stable encoding of the resolved policy (rules, row filters, column cases, sensitive columns, output scan, global salt), and **runtime options** that affect transforms: `--format` and the effective `--seed` / `DUMPLING_SEED` in standard profile (`null` in hardened, where seeds are ignored).
 
-If the **input** already begins with a seal line and it **matches** the current run, Dumpling copies the rest of the file through unchanged. If the line looks like a seal but does **not** match (stale policy, different flags, or older `v=`), that line is **dropped** and the dump is re-processed so you do not end up with two seal lines. `--strict-coverage` cannot be combined with a matching seal (table definitions are not scanned in passthrough mode). `--check` writes no output and therefore emits no seal line. When `--report` is set, the JSON sidecar records the same digest as `seal_sha256` so reviewers can cross-link dump and report (see [Audit evidence](ci-guardrails.md#audit-evidence)).
+**Incoming seals.** If the input already starts with a matching seal, Dumpling copies the rest of the file through unchanged. A seal that does not match (stale policy, different flags, or older `v=`) is dropped and the dump is re-processed so you do not get two seal lines. `--strict-coverage` cannot be combined with a matching seal (table definitions are not scanned in passthrough mode).
+
+**`--check`** writes no output, so it emits no seal line.
+
+### `--no-seal`
+
+Skip writing the comment. Use this for stdin/stdout pipelines where a leading SQL comment is unwanted:
+
+```bash
+cat dump.sql | dumpling --no-seal --report report.json > sanitized.sql
+```
+
+Incoming seal lines are still recognized (match → pass the body through; stale → strip and re-process). `--report` still records the policy fingerprint as `seal_sha256`. See [JSON report (audit sidecar)](#json-report-audit-sidecar) and [Audit evidence](ci-guardrails.md#audit-evidence).
+
+## JSON report (audit sidecar)
+
+`--report <file>` writes a JSON sidecar for the run. Use it as compliance evidence next to (or instead of) a dump-seal comment.
+
+| Field | Stable across re-runs? | Meaning |
+|---|---|---|
+| `dumpling_version` | yes (same binary) | Crate semver |
+| `seal_sha256` | yes (same policy + transform options) | Same digest a dump-seal `sha256=` would carry; present even with `--no-seal` |
+| `config_source` / `config_sha256` | yes (unchanged file) | Path and SHA-256 of the loaded config **file bytes** |
+| `input_sha256` / `output_sha256` | yes (same streams) | SHA-256 of the SQL Dumpling read/wrote (`output_sha256` omitted for `--check`) |
+| `flags` | yes (same CLI) | Includes `check`, `strict_coverage`, `scan_output`, `fail_on_findings`, `no_seal`, `format`, … |
+| `outcomes` | yes (same result) | `strict_coverage_passed` / `output_scan_passed` when those gates ran; `trusted_passthrough` |
+| `run_id` / `started_at` | **no** | Per-invocation identity (`started_at` is RFC 3339 UTC) |
+
+Coverage arrays (`sensitive_columns_*`), `output_scan`, per-table counts, and change events are in the same file. `input_sha256` is over the SQL stream Dumpling actually processed (decoded `pg_restore` output, decompressed gzip, and so on), not necessarily the raw archive on disk.
+
+See [Audit evidence](ci-guardrails.md#audit-evidence) for archival and verification examples.
 
 ## Hardened security profile
 
@@ -146,13 +178,11 @@ dumpling --security-profile hardened -i dump.sql -o sanitized.sql
 
 ### Report metadata
 
-The JSON report always includes the active security profile, plus audit provenance when `--report` is used (`dumpling_version`, `seal_sha256`, config/input/output checksums, gate flags). See [Audit evidence](ci-guardrails.md#audit-evidence).
+The JSON `--report` always includes the active security profile (`"standard"` or `"hardened"`). Full sidecar fields are documented under [JSON report (audit sidecar)](#json-report-audit-sidecar).
 
 ```json
 {
-  "dumpling_version": "0.7.0",
   "security_profile": "hardened",
-  "seal_sha256": "…",
   "total_rows_processed": 1000
 }
 ```
@@ -364,7 +394,7 @@ When `--report` is enabled, coverage fields are added to JSON output:
 - `sensitive_columns_covered`
 - `sensitive_columns_uncovered`
 
-The same JSON file is also the **audit sidecar**: it records Dumpling version, config path + checksum, streaming I/O checksums, the dump-seal digest (`seal_sha256`, matching `sha256=` on the output), gate flags, and coverage/scan outcomes. `run_id` and `started_at` are per-invocation and will not match on re-runs; fingerprint fields are deterministic. See [Audit evidence](ci-guardrails.md#audit-evidence).`
+The same file is the [audit sidecar](#json-report-audit-sidecar) (`dumpling_version`, checksums, `seal_sha256`, gate flags, scan outcomes). `run_id` and `started_at` differ on every invocation; fingerprint fields are deterministic. With `--no-seal` the dump has no seal line, but `seal_sha256` is still in the report. See [Audit evidence](ci-guardrails.md#audit-evidence).
 
 Example CI gate:
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -1,6 +1,6 @@
 # Getting started
 
-This page is the **shortest path** from zero to a first successful run. For strategy details, row filters, dump seals, and CI patterns, continue with the [configuration guide](configuration.md) and the repository `README.md`.
+This page is the **shortest path** from zero to a first successful run. For strategy details, row filters, dump seals (`--no-seal`), the JSON `--report` sidecar, and CI patterns, continue with the [configuration guide](configuration.md) and the repository `README.md`.
 
 ## Prerequisites
 
@@ -46,7 +46,7 @@ dumpling --help
 
 3. **Align rules with your dump (manual path only)** — If you skipped `scaffold-config`, use `CREATE TABLE`, `COPY … (…)`, and `INSERT INTO … (…)` lines to name `[rules."table"]` or `[rules."schema.table"]` keys. Trim to the tables you care about first.
 
-4. **Run Dumpling** — `dumpling -i dump.sql -o sanitized.sql` (add `-c path` if the config is not in the default search path). Use `dumpling --check -i dump.sql` when you only want to know whether anything would change.
+4. **Run Dumpling** — `dumpling -i dump.sql -o sanitized.sql` (add `-c path` if the config is not in the default search path). Use `dumpling --check -i dump.sql` when you only want to know whether anything would change. Output is prefixed with a dump-seal comment by default; pass **`--no-seal`** for stdin/stdout pipelines, and **`--report file.json`** for an audit sidecar (see [Dump seal](configuration.md#dump-seal-on-by-default) and [JSON report](configuration.md#json-report-audit-sidecar)).
 
 5. **Tighten the policy** — Run `dumpling lint-policy` on your config. When you are ready for stricter gates, add `[sensitive_columns]` and use `--strict-coverage`, `--report`, and `--scan-output` as described in the [configuration guide](configuration.md) and the repository `README.md`.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,6 +8,7 @@ This documentation covers the operating model for day-to-day use:
 
 - how to build and run Dumpling locally,
 - how to configure transformation behavior safely,
+- how dump seals, `--no-seal`, and `--report` provide audit evidence,
 - how CI validates quality before changes merge,
 - and how maintainers produce tagged releases.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,11 +36,14 @@ const OUTPUT_PIPE_DEPTH: usize = 8;
 use compressed_input::CompressionCleanup;
 use dump_input_resolve::{resolve_dump_input_from_path, ResolveDumpInputParams};
 use log_sanitize::path_basename_for_log;
-use report::Reporter;
+use report::{
+    generate_run_id, run_timestamp_rfc3339, sha256_hex_of_path, OptionalHashingBufRead,
+    OptionalHashingWriter, Reporter, RunFlags, RunOutcomes,
+};
 use scan::{OutputScanner, ScanningWriter};
 use seal::{
-    compute_seal_digest, format_seal_line, read_first_line_for_seal, FirstLineReplayBufRead,
-    SealFirstLine, SealRuntimeParams,
+    compute_seal_digest, format_seal_line, read_first_line_for_seal, sha256_hex_32,
+    FirstLineReplayBufRead, SealFirstLine, SealRuntimeParams,
 };
 use settings::{merge_keep_original, ResolvedConfig};
 use sql::{DumpFormat, SqlStreamProcessor};
@@ -89,7 +92,7 @@ struct Cli {
     #[arg(long = "stats", action = ArgAction::SetTrue)]
     stats: bool,
 
-    /// Write a detailed JSON report of changes and drops to this file.
+    /// Write a JSON audit sidecar (run provenance, checksums, coverage, and change events) to this file.
     #[arg(long = "report")]
     report: Option<PathBuf>,
 
@@ -507,8 +510,7 @@ fn run_anonymize(cli: Cli) -> anyhow::Result<()> {
     // Determine IO (optional pg_restore child for PostgreSQL custom/directory archives)
     let mut pg_restore_child: Option<pg_restore_decode::PgRestoreDecodeProcess> = None;
     let mut path_to_remove_pg_archive: Option<PathBuf> = None;
-    let (mut reader, input_path_for_inplace): (Box<dyn BufRead>, Option<PathBuf>) = match &cli.input
-    {
+    let (reader, input_path_for_inplace): (Box<dyn BufRead>, Option<PathBuf>) = match &cli.input {
         None => {
             if !cli.allow_ext.is_empty() {
                 eprintln!("dumpling: --allow-ext provided but no --input file; extension check is ignored for stdin");
@@ -583,12 +585,45 @@ fn run_anonymize(cli: Cli) -> anyhow::Result<()> {
     };
 
     // Prepare reporter if requested
-    let mut reporter = cli
-        .report
-        .as_ref()
-        .map(|_| Reporter::new(true))
-        .unwrap_or_else(|| Reporter::new(false));
+    let report_requested = cli.report.is_some();
+    let (config_source, config_sha256) = if report_requested {
+        match resolved_config.source_path.as_ref() {
+            Some(p) => (
+                Some(p.to_string_lossy().into_owned()),
+                Some(sha256_hex_of_path(p)?),
+            ),
+            None => (None, None),
+        }
+    } else {
+        (None, None)
+    };
+    let mut reporter = if report_requested {
+        Reporter::new(true)
+    } else {
+        Reporter::new(false)
+    };
     reporter.report.security_profile = security_profile_name.to_string();
+    if report_requested {
+        reporter.report.dumpling_version = env!("CARGO_PKG_VERSION").to_string();
+        reporter.report.run_id = generate_run_id();
+        reporter.report.started_at = run_timestamp_rfc3339();
+        reporter.report.config_source = config_source;
+        reporter.report.config_sha256 = config_sha256;
+        reporter.report.flags = RunFlags {
+            check: cli.check,
+            strict_coverage: cli.strict_coverage,
+            scan_output: scan_requested,
+            fail_on_findings: cli.fail_on_findings,
+            allow_noop: cli.allow_noop,
+            in_place: cli.in_place,
+            format: match dump_format {
+                DumpFormat::Postgres => "postgres",
+                DumpFormat::Sqlite => "sqlite",
+                DumpFormat::MsSql => "mssql",
+            }
+            .to_string(),
+        };
+    }
 
     let mut processor = SqlStreamProcessor::new(
         anonymizers,
@@ -597,26 +632,29 @@ fn run_anonymize(cli: Cli) -> anyhow::Result<()> {
         dump_format,
     );
 
-    let seal_digest = if cli.check {
-        None
-    } else {
-        Some(compute_seal_digest(
-            processor.config_snapshot(),
-            security_profile_name,
-            &seal_runtime,
-        )?)
-    };
-
-    let mut writer = anon_writer;
-
-    let seal_first = read_first_line_for_seal(
-        reader.as_mut(),
+    let seal_digest_bytes = compute_seal_digest(
         processor.config_snapshot(),
         security_profile_name,
         &seal_runtime,
     )?;
+    if report_requested {
+        reporter.report.seal_sha256 = Some(sha256_hex_32(&seal_digest_bytes));
+    }
+    let write_seal = !cli.check;
 
-    if matches!(seal_first, SealFirstLine::TrustedPassthrough) && cli.strict_coverage {
+    let mut hashing_reader = OptionalHashingBufRead::new(reader, report_requested);
+    let mut hashing_writer =
+        OptionalHashingWriter::new(anon_writer, report_requested && !cli.check);
+
+    let seal_first = read_first_line_for_seal(
+        &mut hashing_reader,
+        processor.config_snapshot(),
+        security_profile_name,
+        &seal_runtime,
+    )?;
+    let trusted_passthrough = matches!(seal_first, SealFirstLine::TrustedPassthrough);
+
+    if trusted_passthrough && cli.strict_coverage {
         anyhow::bail!(
             "--strict-coverage cannot be used when the input begins with a matching seal; \
              the dump is passed through without parsing table definitions"
@@ -628,32 +666,31 @@ fn run_anonymize(cli: Cli) -> anyhow::Result<()> {
         SealFirstLine::Replay(v) if v.is_empty() => None,
         SealFirstLine::Replay(v) => Some(v.clone()),
     };
-    let mut adapted_reader = FirstLineReplayBufRead::new(reader.as_mut(), replay_first);
 
     let run_started = Instant::now();
-    let proc_res: anyhow::Result<()> = if matches!(seal_first, SealFirstLine::TrustedPassthrough) {
-        if let Some(ref digest) = seal_digest {
-            writer.write_all(format_seal_line(security_profile_name, digest).as_bytes())?;
+    let proc_res: anyhow::Result<()> = {
+        let mut adapted_reader = FirstLineReplayBufRead::new(&mut hashing_reader, replay_first);
+        if write_seal {
+            hashing_writer.write_all(
+                format_seal_line(security_profile_name, &seal_digest_bytes).as_bytes(),
+            )?;
         }
-        if let Some(scanner) = output_scanner.as_mut() {
-            let mut scanning_writer = ScanningWriter::new(&mut writer, scanner);
-            std::io::copy(&mut adapted_reader, &mut scanning_writer)
-                .map(|_| ())
-                .map_err(anyhow::Error::from)
-        } else {
-            std::io::copy(&mut adapted_reader, &mut writer)
-                .map(|_| ())
-                .map_err(anyhow::Error::from)
-        }
-    } else {
-        if let Some(ref digest) = seal_digest {
-            writer.write_all(format_seal_line(security_profile_name, digest).as_bytes())?;
-        }
-        if let Some(scanner) = output_scanner.as_mut() {
-            let mut scanning_writer = ScanningWriter::new(&mut writer, scanner);
+        if trusted_passthrough {
+            if let Some(scanner) = output_scanner.as_mut() {
+                let mut scanning_writer = ScanningWriter::new(&mut hashing_writer, scanner);
+                std::io::copy(&mut adapted_reader, &mut scanning_writer)
+                    .map(|_| ())
+                    .map_err(anyhow::Error::from)
+            } else {
+                std::io::copy(&mut adapted_reader, &mut hashing_writer)
+                    .map(|_| ())
+                    .map_err(anyhow::Error::from)
+            }
+        } else if let Some(scanner) = output_scanner.as_mut() {
+            let mut scanning_writer = ScanningWriter::new(&mut hashing_writer, scanner);
             processor.process(&mut adapted_reader, &mut scanning_writer)
         } else {
-            processor.process(&mut adapted_reader, &mut writer)
+            processor.process(&mut adapted_reader, &mut hashing_writer)
         }
     };
 
@@ -662,6 +699,9 @@ fn run_anonymize(cli: Cli) -> anyhow::Result<()> {
     }
 
     proc_res?;
+    if let Some(digest) = hashing_reader.finalize() {
+        reporter.report.input_sha256 = Some(sha256_hex_32(&digest));
+    }
     let coverage = processor.sensitive_coverage_summary();
     reporter.report.sensitive_columns_detected = coverage.detected.clone();
     reporter.report.sensitive_columns_covered = coverage.covered.clone();
@@ -680,11 +720,29 @@ fn run_anonymize(cli: Cli) -> anyhow::Result<()> {
         }
         reporter.report.output_scan = Some(scan_report);
     }
+    if report_requested {
+        reporter.report.outcomes = RunOutcomes {
+            strict_coverage_passed: cli.strict_coverage.then_some(!strict_coverage_failed),
+            output_scan_passed: reporter
+                .report
+                .output_scan
+                .as_ref()
+                .map(|scan| !scan.failed),
+            trusted_passthrough,
+        };
+    }
     if strict_coverage_failed {
         eprintln!(
             "dumpling: strict coverage failed; uncovered sensitive columns: {}",
             coverage.uncovered.join(", ")
         );
+    }
+
+    let (writer, output_digest) = hashing_writer.finish();
+    if report_requested && !cli.check {
+        if let Some(digest) = output_digest {
+            reporter.report.output_sha256 = Some(sha256_hex_32(&digest));
+        }
     }
 
     // Close the output stream (piped file writer joins its thread here).
@@ -902,6 +960,158 @@ email = { strategy = "email" }
         let _ = fs::remove_file(&pass1_in);
         let _ = fs::remove_file(&pass1_out);
         let _ = fs::remove_file(&pass2_out);
+    }
+
+    fn sha256_file(path: &std::path::Path) -> String {
+        crate::report::sha256_hex(&fs::read(path).unwrap())
+    }
+
+    #[test]
+    fn report_audit_sidecar_checksums_and_seal_cross_link() {
+        let exe = match option_env!("CARGO_BIN_EXE_dumpling") {
+            Some(p) => PathBuf::from(p),
+            None => return,
+        };
+        let base =
+            std::env::temp_dir().join(format!("dumpling_audit_report_{}", std::process::id()));
+        let conf = base.with_extension("toml");
+        let input = base.with_extension("in.sql");
+        let out1 = base.with_extension("out1.sql");
+        let out2 = base.with_extension("out2.sql");
+        let report1 = base.with_extension("r1.json");
+        let report2 = base.with_extension("r2.json");
+        let check_report = base.with_extension("check.json");
+
+        let conf_body = r#"
+[rules."public.users"]
+email = { strategy = "email" }
+
+[sensitive_columns]
+"public.users" = ["email"]
+"#;
+        fs::write(&conf, conf_body).unwrap();
+        fs::write(
+            &input,
+            "INSERT INTO public.users (email) VALUES ('alice@example.com');\n",
+        )
+        .unwrap();
+
+        let run = |output: &std::path::Path, report: &std::path::Path| {
+            Command::new(&exe)
+                .args([
+                    "-c",
+                    conf.to_str().unwrap(),
+                    "-i",
+                    input.to_str().unwrap(),
+                    "-o",
+                    output.to_str().unwrap(),
+                    "--report",
+                    report.to_str().unwrap(),
+                    "--strict-coverage",
+                    "--seed",
+                    "42",
+                ])
+                .output()
+                .unwrap()
+        };
+
+        let s1 = run(&out1, &report1);
+        assert!(
+            s1.status.success(),
+            "run1 stderr={}",
+            String::from_utf8_lossy(&s1.stderr)
+        );
+        let s2 = run(&out2, &report2);
+        assert!(
+            s2.status.success(),
+            "run2 stderr={}",
+            String::from_utf8_lossy(&s2.stderr)
+        );
+
+        let v1: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&report1).unwrap()).unwrap();
+        let v2: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&report2).unwrap()).unwrap();
+
+        assert_eq!(v1["dumpling_version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(v1["security_profile"], "standard");
+        assert_eq!(v1["flags"]["check"], false);
+        assert_eq!(v1["flags"]["strict_coverage"], true);
+        assert_eq!(v1["flags"]["scan_output"], false);
+        assert_eq!(v1["flags"]["format"], "postgres");
+        assert_eq!(v1["outcomes"]["strict_coverage_passed"], true);
+        assert_eq!(v1["outcomes"]["trusted_passthrough"], false);
+        assert!(v1["outcomes"].get("output_scan_passed").is_none());
+
+        let config_source = v1["config_source"].as_str().unwrap();
+        assert!(
+            config_source.ends_with(conf.file_name().unwrap().to_str().unwrap()),
+            "config_source={config_source}"
+        );
+        assert_eq!(v1["config_sha256"], sha256_file(&conf));
+        assert_eq!(v1["input_sha256"], sha256_file(&input));
+        assert_eq!(v1["output_sha256"], sha256_file(&out1));
+
+        let mut sealed = String::new();
+        fs::File::open(&out1)
+            .unwrap()
+            .read_to_string(&mut sealed)
+            .unwrap();
+        let seal_hex = sealed
+            .lines()
+            .next()
+            .unwrap()
+            .split("sha256=")
+            .nth(1)
+            .unwrap()
+            .trim();
+        assert_eq!(v1["seal_sha256"], seal_hex);
+
+        assert_eq!(v1["seal_sha256"], v2["seal_sha256"]);
+        assert_eq!(v1["config_sha256"], v2["config_sha256"]);
+        assert_eq!(v1["input_sha256"], v2["input_sha256"]);
+        assert_eq!(v1["output_sha256"], v2["output_sha256"]);
+        assert_eq!(v1["dumpling_version"], v2["dumpling_version"]);
+        assert_ne!(v1["run_id"], v2["run_id"]);
+        assert!(!v1["run_id"].as_str().unwrap().is_empty());
+        assert!(v1["started_at"].as_str().unwrap().ends_with('Z'));
+
+        let check = Command::new(&exe)
+            .args([
+                "-c",
+                conf.to_str().unwrap(),
+                "-i",
+                input.to_str().unwrap(),
+                "--check",
+                "--keep-original",
+                "--report",
+                check_report.to_str().unwrap(),
+                "--seed",
+                "42",
+            ])
+            .output()
+            .unwrap();
+        // --check exits 1 when cells change
+        assert_eq!(
+            check.status.code(),
+            Some(1),
+            "check stderr={}",
+            String::from_utf8_lossy(&check.stderr)
+        );
+        let vc: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&check_report).unwrap()).unwrap();
+        assert_eq!(vc["flags"]["check"], true);
+        assert!(vc.get("output_sha256").is_none());
+        assert_eq!(vc["seal_sha256"], v1["seal_sha256"]);
+        assert_eq!(vc["input_sha256"], v1["input_sha256"]);
+
+        let _ = fs::remove_file(&conf);
+        let _ = fs::remove_file(&input);
+        let _ = fs::remove_file(&out1);
+        let _ = fs::remove_file(&out2);
+        let _ = fs::remove_file(&report1);
+        let _ = fs::remove_file(&report2);
+        let _ = fs::remove_file(&check_report);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,14 @@ use transform::{
     name = "dumpling",
     author,
     version,
-    about = "Static anonymizer for SQL dumps. Supports PostgreSQL (pg_dump plain format), SQLite (.dump), and SQL Server (SSMS / mssql-scripter plain SQL)."
+    about = "Static anonymizer for SQL dumps. Supports PostgreSQL (pg_dump plain format), SQLite (.dump), and SQL Server (SSMS / mssql-scripter plain SQL).",
+    after_help = "\
+Examples:
+  dumpling -i dump.sql -o sanitized.sql
+  dumpling --report report.json -i dump.sql -o sanitized.sql
+  cat dump.sql | dumpling --no-seal --report report.json > sanitized.sql
+  dumpling --check --strict-coverage --report coverage.json -i dump.sql
+"
 )]
 struct Cli {
     /// Input SQL file path (default: stdin)
@@ -92,9 +99,25 @@ struct Cli {
     #[arg(long = "stats", action = ArgAction::SetTrue)]
     stats: bool,
 
-    /// Write a JSON audit sidecar (run provenance, checksums, coverage, and change events) to this file.
+    /// Write a JSON audit sidecar to this file (provenance, checksums, coverage, change events).
+    ///
+    /// Always includes Dumpling version, run id/timestamp, config path + SHA-256, streaming
+    /// input/output SHA-256, `seal_sha256` (same digest as a dump-seal `sha256=` field), gate
+    /// flags, and coverage/scan outcomes. `output_sha256` is omitted in `--check`. Pair with
+    /// `--no-seal` when the SQL stream should not carry a dump-seal comment.
+    ///
+    /// Example: `dumpling --report report.json -i dump.sql -o sanitized.sql`
     #[arg(long = "report")]
     report: Option<PathBuf>,
+
+    /// Do not prefix output with a dump-seal SQL comment.
+    ///
+    /// Incoming seal lines are still recognized (a matching seal passes the body through; a stale
+    /// seal is stripped and the dump is re-processed). `--report` still records `seal_sha256`.
+    ///
+    /// Example: `cat dump.sql | dumpling --no-seal --report report.json > sanitized.sql`
+    #[arg(long = "no-seal", action = ArgAction::SetTrue)]
+    no_seal: bool,
 
     /// Enforce explicit coverage for sensitive columns; exits non-zero when uncovered columns exist.
     #[arg(long = "strict-coverage", action = ArgAction::SetTrue)]
@@ -616,6 +639,7 @@ fn run_anonymize(cli: Cli) -> anyhow::Result<()> {
             fail_on_findings: cli.fail_on_findings,
             allow_noop: cli.allow_noop,
             in_place: cli.in_place,
+            no_seal: cli.no_seal,
             format: match dump_format {
                 DumpFormat::Postgres => "postgres",
                 DumpFormat::Sqlite => "sqlite",
@@ -640,7 +664,7 @@ fn run_anonymize(cli: Cli) -> anyhow::Result<()> {
     if report_requested {
         reporter.report.seal_sha256 = Some(sha256_hex_32(&seal_digest_bytes));
     }
-    let write_seal = !cli.check;
+    let write_seal = !cli.check && !cli.no_seal;
 
     let mut hashing_reader = OptionalHashingBufRead::new(reader, report_requested);
     let mut hashing_writer =
@@ -858,7 +882,7 @@ pub(crate) fn has_allowed_extension(path: &Path, allow_exts: &[String]) -> bool 
 #[cfg(test)]
 mod tests_main {
     use super::{has_allowed_extension, Cli, Commands};
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
     use std::fs;
     use std::io::Read;
     use std::path::PathBuf;
@@ -1038,6 +1062,7 @@ email = { strategy = "email" }
         assert_eq!(v1["flags"]["check"], false);
         assert_eq!(v1["flags"]["strict_coverage"], true);
         assert_eq!(v1["flags"]["scan_output"], false);
+        assert_eq!(v1["flags"]["no_seal"], false);
         assert_eq!(v1["flags"]["format"], "postgres");
         assert_eq!(v1["outcomes"]["strict_coverage_passed"], true);
         assert_eq!(v1["outcomes"]["trusted_passthrough"], false);
@@ -1115,6 +1140,82 @@ email = { strategy = "email" }
     }
 
     #[test]
+    fn no_seal_omits_dump_seal_comment_but_report_keeps_digest() {
+        let exe = match option_env!("CARGO_BIN_EXE_dumpling") {
+            Some(p) => PathBuf::from(p),
+            None => return,
+        };
+        let base = std::env::temp_dir().join(format!("dumpling_no_seal_{}", std::process::id()));
+        let conf = base.with_extension("toml");
+        let input = base.with_extension("in.sql");
+        let output = base.with_extension("out.sql");
+        let report = base.with_extension("json");
+
+        fs::write(
+            &conf,
+            r#"
+[rules."public.users"]
+email = { strategy = "email" }
+"#,
+        )
+        .unwrap();
+        fs::write(
+            &input,
+            "INSERT INTO public.users (email) VALUES ('alice@example.com');\n",
+        )
+        .unwrap();
+
+        let run = Command::new(&exe)
+            .args([
+                "-c",
+                conf.to_str().unwrap(),
+                "-i",
+                input.to_str().unwrap(),
+                "-o",
+                output.to_str().unwrap(),
+                "--report",
+                report.to_str().unwrap(),
+                "--no-seal",
+                "--seed",
+                "42",
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            run.status.success(),
+            "stderr={}",
+            String::from_utf8_lossy(&run.stderr)
+        );
+
+        let out = fs::read_to_string(&output).unwrap();
+        assert!(
+            !out.contains("-- dumpling-seal:"),
+            "expected no seal comment, got: {out:?}"
+        );
+        assert!(
+            !out.contains("alice@example.com"),
+            "expected anonymization without a seal prefix"
+        );
+        assert!(
+            out.contains("INSERT INTO public.users"),
+            "expected transformed SQL body"
+        );
+
+        let v: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&report).unwrap()).unwrap();
+        assert_eq!(v["flags"]["no_seal"], true);
+        let digest = v["seal_sha256"].as_str().expect("seal_sha256");
+        assert_eq!(digest.len(), 64);
+        assert!(digest.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(v["output_sha256"], sha256_file(&output));
+
+        let _ = fs::remove_file(&conf);
+        let _ = fs::remove_file(&input);
+        let _ = fs::remove_file(&output);
+        let _ = fs::remove_file(&report);
+    }
+
+    #[test]
     fn test_allowed_extensions() {
         let p = PathBuf::from("/tmp/foo.dmp");
         assert!(has_allowed_extension(&p, &["dmp".into()]));
@@ -1128,6 +1229,35 @@ email = { strategy = "email" }
     fn test_allow_noop_flag_parses() {
         let cli = Cli::parse_from(["dumpling", "--allow-noop"]);
         assert!(cli.allow_noop);
+    }
+
+    #[test]
+    fn test_no_seal_flag_parses() {
+        let cli = Cli::parse_from(["dumpling", "--no-seal"]);
+        assert!(cli.no_seal);
+        let default = Cli::parse_from(["dumpling"]);
+        assert!(!default.no_seal);
+    }
+
+    #[test]
+    fn test_help_documents_report_no_seal_and_examples() {
+        let mut cmd = Cli::command();
+        let mut buf = Vec::new();
+        cmd.write_long_help(&mut buf).unwrap();
+        let help = String::from_utf8(buf).unwrap();
+        assert!(
+            help.contains("Examples:"),
+            "expected Examples section in --help"
+        );
+        assert!(help.contains("--no-seal"), "expected --no-seal in --help");
+        assert!(
+            help.contains("audit sidecar") || help.contains("--report"),
+            "expected --report documented in --help"
+        );
+        assert!(
+            help.contains("cat dump.sql | dumpling --no-seal"),
+            "expected streaming --no-seal example in --help"
+        );
     }
 
     #[test]

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,9 +1,39 @@
+use anyhow::Context;
+use chrono::SecondsFormat;
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
+use std::io::{BufRead, Read, Write};
+use std::path::Path;
+
+use crate::seal::sha256_hex_32;
 
 #[derive(Debug, Serialize, Clone)]
 pub struct Report {
+    /// Crate semver. Deterministic for a given Dumpling build.
+    pub dumpling_version: String,
+    /// Instance metadata: unique per invocation (will not match on re-runs).
+    pub run_id: String,
+    /// Instance metadata: RFC 3339 UTC timestamp when the run started (will not match on re-runs).
+    pub started_at: String,
     pub security_profile: String,
+    /// Path of the loaded config file (`None` when `--allow-noop` ran without a config).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_source: Option<String>,
+    /// SHA-256 of the config file bytes as loaded (not the resolved/secret-substituted policy).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_sha256: Option<String>,
+    /// SHA-256 of the SQL byte stream Dumpling actually read (decoded/decompressed when applicable).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_sha256: Option<String>,
+    /// SHA-256 of bytes written to the output stream, including the dump-seal line. Omitted in `--check`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_sha256: Option<String>,
+    /// Same SHA-256 hex as the dump-seal `sha256=` field (policy + version + profile + transform runtime).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seal_sha256: Option<String>,
+    pub flags: RunFlags,
+    pub outcomes: RunOutcomes,
     pub total_rows_processed: u64,
     pub total_rows_dropped: u64,
     pub total_cells_changed: u64,
@@ -22,7 +52,17 @@ pub struct Report {
 impl Default for Report {
     fn default() -> Self {
         Self {
+            dumpling_version: env!("CARGO_PKG_VERSION").to_string(),
+            run_id: String::new(),
+            started_at: String::new(),
             security_profile: "standard".to_string(),
+            config_source: None,
+            config_sha256: None,
+            input_sha256: None,
+            output_sha256: None,
+            seal_sha256: None,
+            flags: RunFlags::default(),
+            outcomes: RunOutcomes::default(),
             total_rows_processed: 0,
             total_rows_dropped: 0,
             total_cells_changed: 0,
@@ -35,6 +75,42 @@ impl Default for Report {
             deterministic_mapping_domains: Vec::new(),
         }
     }
+}
+
+/// Explicit CLI gate / run flags recorded in the audit sidecar.
+#[derive(Debug, Serialize, Clone)]
+pub struct RunFlags {
+    pub check: bool,
+    pub strict_coverage: bool,
+    pub scan_output: bool,
+    pub fail_on_findings: bool,
+    pub allow_noop: bool,
+    pub in_place: bool,
+    pub format: String,
+}
+
+impl Default for RunFlags {
+    fn default() -> Self {
+        Self {
+            check: false,
+            strict_coverage: false,
+            scan_output: false,
+            fail_on_findings: false,
+            allow_noop: false,
+            in_place: false,
+            format: "postgres".to_string(),
+        }
+    }
+}
+
+/// Validation outcomes. Gate-specific fields are omitted when that gate was not enabled.
+#[derive(Debug, Default, Serialize, Clone)]
+pub struct RunOutcomes {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strict_coverage_passed: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_scan_passed: Option<bool>,
+    pub trusted_passthrough: bool,
 }
 
 #[derive(Debug, Default, Serialize, Clone)]
@@ -194,5 +270,233 @@ fn qualified(schema: Option<&str>, table: &str) -> String {
     match schema {
         Some(s) => format!("{}.{}", s, table),
         None => table.to_string(),
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push(HEX[(b >> 4) as usize] as char);
+        s.push(HEX[(b & 0xf) as usize] as char);
+    }
+    s
+}
+
+pub(crate) fn generate_run_id() -> String {
+    let mut bytes = [0u8; 16];
+    if getrandom::getrandom(&mut bytes).is_err() {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        bytes = nanos.to_le_bytes();
+        let pid = (std::process::id() as u64).to_le_bytes();
+        for (i, b) in pid.iter().enumerate() {
+            bytes[i] ^= b;
+        }
+    }
+    hex_encode(&bytes)
+}
+
+pub(crate) fn run_timestamp_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+pub(crate) fn sha256_hex(data: &[u8]) -> String {
+    sha256_hex_32(&Sha256::digest(data).into())
+}
+
+pub(crate) fn sha256_hex_of_path(path: &Path) -> anyhow::Result<String> {
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("failed hashing config file {}", path.display()))?;
+    Ok(sha256_hex(&bytes))
+}
+
+/// Streaming SHA-256 over a `BufRead`, hashed on `consume` so `read_line` is counted once.
+pub(crate) struct OptionalHashingBufRead<R: BufRead> {
+    inner: R,
+    hasher: Option<Sha256>,
+}
+
+impl<R: BufRead> OptionalHashingBufRead<R> {
+    pub(crate) fn new(inner: R, enabled: bool) -> Self {
+        Self {
+            inner,
+            hasher: enabled.then(Sha256::new),
+        }
+    }
+
+    pub(crate) fn finalize(self) -> Option<[u8; 32]> {
+        self.hasher.map(|h| h.finalize().into())
+    }
+}
+
+impl<R: BufRead> Read for OptionalHashingBufRead<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let available = self.fill_buf()?;
+        let n = available.len().min(buf.len());
+        buf[..n].copy_from_slice(&available[..n]);
+        self.consume(n);
+        Ok(n)
+    }
+}
+
+impl<R: BufRead> BufRead for OptionalHashingBufRead<R> {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    fn consume(&mut self, amt: usize) {
+        if let Some(hasher) = self.hasher.as_mut() {
+            if amt > 0 {
+                if let Ok(buf) = self.inner.fill_buf() {
+                    let n = amt.min(buf.len());
+                    hasher.update(&buf[..n]);
+                }
+            }
+        }
+        self.inner.consume(amt);
+    }
+}
+
+pub(crate) struct OptionalHashingWriter<W: Write> {
+    inner: W,
+    hasher: Option<Sha256>,
+}
+
+impl<W: Write> OptionalHashingWriter<W> {
+    pub(crate) fn new(inner: W, enabled: bool) -> Self {
+        Self {
+            inner,
+            hasher: enabled.then(Sha256::new),
+        }
+    }
+
+    pub(crate) fn finish(self) -> (W, Option<[u8; 32]>) {
+        let digest = self.hasher.map(|h| h.finalize().into());
+        (self.inner, digest)
+    }
+}
+
+impl<W: Write> Write for OptionalHashingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let n = self.inner.write(buf)?;
+        if n > 0 {
+            if let Some(hasher) = self.hasher.as_mut() {
+                hasher.update(&buf[..n]);
+            }
+        }
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    const SHA256_ABC: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+    const SHA256_EMPTY: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    #[test]
+    fn hashing_writer_matches_sha256_of_abc() {
+        let mut sink = Vec::new();
+        let mut w = OptionalHashingWriter::new(&mut sink, true);
+        w.write_all(b"abc").unwrap();
+        let (_, digest) = w.finish();
+        assert_eq!(sha256_hex_32(&digest.unwrap()), SHA256_ABC);
+        assert_eq!(sink, b"abc");
+    }
+
+    #[test]
+    fn hashing_bufread_matches_sha256_of_abc() {
+        let mut cursor = std::io::Cursor::new(b"abc".as_slice());
+        let mut r = OptionalHashingBufRead::new(&mut cursor, true);
+        let mut buf = String::new();
+        r.read_to_string(&mut buf).unwrap();
+        assert_eq!(buf, "abc");
+        let digest = r.finalize().unwrap();
+        assert_eq!(sha256_hex_32(&digest), SHA256_ABC);
+    }
+
+    #[test]
+    fn hashing_bufread_hashes_read_line_path() {
+        let data = b"hello\nworld\n";
+        let mut cursor = std::io::Cursor::new(data.as_slice());
+        let mut r = OptionalHashingBufRead::new(&mut cursor, true);
+        let mut line = String::new();
+        assert!(r.read_line(&mut line).unwrap() > 0);
+        line.clear();
+        assert!(r.read_line(&mut line).unwrap() > 0);
+        let digest = r.finalize().unwrap();
+        assert_eq!(sha256_hex_32(&digest), sha256_hex(data));
+    }
+
+    #[test]
+    fn hashing_disabled_returns_no_digest() {
+        let mut sink = Vec::new();
+        let mut w = OptionalHashingWriter::new(&mut sink, false);
+        w.write_all(b"abc").unwrap();
+        let (_, digest) = w.finish();
+        assert!(digest.is_none());
+        assert_eq!(sink, b"abc");
+    }
+
+    #[test]
+    fn hashing_writer_empty_is_empty_digest() {
+        let sink = Vec::new();
+        let w = OptionalHashingWriter::new(sink, true);
+        let (_, digest) = w.finish();
+        assert_eq!(sha256_hex_32(&digest.unwrap()), SHA256_EMPTY);
+    }
+
+    #[test]
+    fn report_serializes_audit_fields_and_omits_absent_checksums() {
+        let mut report = Report {
+            dumpling_version: "0.7.0".into(),
+            run_id: "abc123".into(),
+            started_at: "2026-08-14T00:00:00Z".into(),
+            seal_sha256: Some("deadbeef".into()),
+            flags: RunFlags {
+                check: true,
+                strict_coverage: true,
+                scan_output: true,
+                fail_on_findings: true,
+                allow_noop: false,
+                in_place: false,
+                format: "postgres".into(),
+            },
+            outcomes: RunOutcomes {
+                strict_coverage_passed: Some(true),
+                output_scan_passed: Some(true),
+                trusted_passthrough: false,
+            },
+            ..Report::default()
+        };
+        report.security_profile = "hardened".into();
+        let v = serde_json::to_value(&report).unwrap();
+        assert_eq!(v["dumpling_version"], "0.7.0");
+        assert_eq!(v["run_id"], "abc123");
+        assert_eq!(v["started_at"], "2026-08-14T00:00:00Z");
+        assert_eq!(v["security_profile"], "hardened");
+        assert_eq!(v["seal_sha256"], "deadbeef");
+        assert_eq!(v["flags"]["strict_coverage"], true);
+        assert_eq!(v["outcomes"]["strict_coverage_passed"], true);
+        assert!(v.get("config_source").is_none());
+        assert!(v.get("config_sha256").is_none());
+        assert!(v.get("input_sha256").is_none());
+        assert!(v.get("output_sha256").is_none());
+    }
+
+    #[test]
+    fn generate_run_id_is_32_hex_chars() {
+        let id = generate_run_id();
+        assert_eq!(id.len(), 32);
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
     }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -26,7 +26,7 @@ pub struct Report {
     /// SHA-256 of the SQL byte stream Dumpling actually read (decoded/decompressed when applicable).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_sha256: Option<String>,
-    /// SHA-256 of bytes written to the output stream, including the dump-seal line. Omitted in `--check`.
+    /// SHA-256 of bytes written to the output stream (includes the dump-seal line when a seal is written). Omitted in `--check`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output_sha256: Option<String>,
     /// Same SHA-256 hex as the dump-seal `sha256=` field (policy + version + profile + transform runtime).
@@ -86,6 +86,7 @@ pub struct RunFlags {
     pub fail_on_findings: bool,
     pub allow_noop: bool,
     pub in_place: bool,
+    pub no_seal: bool,
     pub format: String,
 }
 
@@ -98,6 +99,7 @@ impl Default for RunFlags {
             fail_on_findings: false,
             allow_noop: false,
             in_place: false,
+            no_seal: false,
             format: "postgres".to_string(),
         }
     }
@@ -469,6 +471,7 @@ mod tests {
                 fail_on_findings: true,
                 allow_noop: false,
                 in_place: false,
+                no_seal: true,
                 format: "postgres".into(),
             },
             outcomes: RunOutcomes {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the **narrower scope** of [#13](https://github.com/ababic/dumpling/issues/13): treat dump seals as provenance on the SQL artifact, and expand `--report` into the compliance sidecar (not a second copy of the policy fingerprint).

## `--report` audit sidecar

When `--report` is set, the JSON file records:

- `dumpling_version`
- `run_id` / `started_at` (instance metadata; **will not** match on re-runs)
- `config_source` + `config_sha256` (SHA-256 of the loaded config **file bytes**)
- Streaming `input_sha256` / `output_sha256` of the SQL streams Dumpling actually read/wrote (`output_sha256` omitted in `--check`)
- `seal_sha256` — **the same digest** as dump-seal `sha256=` (cross-link report ↔ dump)
- `flags` for gates (`check`, `strict_coverage`, `scan_output`, `fail_on_findings`, `no_seal`, …)
- `outcomes` (`strict_coverage_passed`, `output_scan_passed` when those gates ran, `trusted_passthrough`)

I/O hashing is enabled only when `--report` is requested.

## `--no-seal`

Skip writing the `-- dumpling-seal:` SQL comment (useful for stdin/stdout pipelines). Incoming seals are still recognized. `--report` still records `seal_sha256`.

```bash
cat dump.sql | dumpling --no-seal --report report.json > sanitized.sql
```

## Docs

- `dumpling --help` long help for `--report` / `--no-seal`, plus an Examples block
- Configuration guide: [Dump seal](docs/src/configuration.md) and [JSON report (audit sidecar)](docs/src/configuration.md)
- [CI guardrails → Audit evidence](docs/src/ci-guardrails.md) covers verification **with** a seal line and **with `--no-seal`**

## Testing

- Unit tests for streaming SHA-256 wrappers and report serialization
- CLI integration: two seeded runs share fingerprint/checksum fields and differ on `run_id`; `--check` omits `output_sha256`; `--no-seal` omits the SQL comment but keeps `seal_sha256`
- `--help` contains Examples, `--no-seal`, and `--report`
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features`, `cargo test --all-targets --all-features` (172 tests)

Closes #13

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2e3c480-a764-46cf-91f1-a63a1b8587aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2e3c480-a764-46cf-91f1-a63a1b8587aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

