### PR TITLE
feat: opt-in FK cascade retain for row_filters (#88)

### DIFF
--- a/.dumplingconf.example
+++ b/.dumplingconf.example
@@ -140,6 +140,20 @@ delete = [
 # ]
 
 # ---------------------------------------------------------------------------
+# [[row_filters."<parent>".cascade]] — related-row retain (opt-in)
+#
+# Keep child rows whose FK matches a retained parent PK. Parent data must
+# appear before child data in the dump (streaming, single-pass).
+# ---------------------------------------------------------------------------
+# [row_filters."public.listing_order"]
+# retain = [{ column = "status", op = "eq", value = "open" }]
+#
+# [[row_filters."public.listing_order".cascade]]
+# child_table = "public.listing_orderitem"
+# child_fk = "order_id"
+# parent_pk = "id"
+
+# ---------------------------------------------------------------------------
 # [[column_cases]] — conditional per-column strategy overrides
 #
 # For each row and column, Dumpling evaluates cases top-to-bottom and applies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,7 @@ Two code paths:
 `should_keep_row` evaluates `RowFilterSet`:
 - `retain` (OR): if non-empty, a row is kept only if at least one predicate matches.
 - `delete` (any-match): if any predicate matches, the row is dropped (evaluated after `retain`).
+- Optional `cascade` (on the parent): `CascadeTracker` in `SqlStreamProcessor` records retained parent PK values and drops child rows whose FK is not in that set. Parent data must appear before children (single-pass).
 
 JSON path traversal is supported: `payload.profile.tier` (dot) and `payload__profile__tier` (Django double-underscore). Array elements are traversed by evaluating each item's fields, so list-of-dicts structures work naturally.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Added
 
 - **Datetime / date predicate comparisons**: `lt` / `lte` / `gt` / `gte` / `eq` / `neq` accept optional `format = "datetime"` (ISO-8601 / Postgres timestamp text as instants) or `format = "date"` (calendar dates). Thresholds are validated at config load; unparseable cell values fail closed ([#87](https://github.com/ababic/dumpling/issues/87)).
+- **`row_filters` cascade retain**: optional `[[row_filters."<parent>".cascade]]` entries keep child rows whose FK matches retained parent PKs (parent-before-child dump order required) ([#88](https://github.com/ababic/dumpling/issues/88)).
 
 ## [0.8.0] - 2026-08-14
 

--- a/README.md
+++ b/README.md
@@ -392,6 +392,30 @@ retain = [
 
 Row filtering works for both `INSERT ... VALUES (...)` and `COPY ... FROM stdin` rows.
 
+#### Related-row cascade retain (opt-in)
+
+`row_filters` are per-table. To keep child rows only when their parent survived filtering, declare `[[row_filters."<parent>".cascade]]` entries on the **parent**:
+
+```toml
+[row_filters."public.listing_order"]
+retain = [{ column = "status", op = "eq", value = "open" }]
+
+[[row_filters."public.listing_order".cascade]]
+child_table = "public.listing_orderitem"
+child_fk = "order_id"
+parent_pk = "id"
+```
+
+Behavior:
+
+- While streaming the parent table, Dumpling records `parent_pk` values of **kept** rows.
+- Child rows are kept only when `child_fk` is in that retained set (and any local retain/delete on the child still apply).
+- `NULL` foreign keys are dropped.
+- **Parent data must appear before child data** in the dump (single-pass streaming). If a cascade child is encountered before its parent, Dumpling exits with an error.
+- Retained key sets are held in memory for the run; prefer selective parent `retain` predicates for large tables.
+
+This is intentionally opt-in and shallow (explicit parent→child links only)—not automatic FK discovery or full graph topological sorting.
+
 ---
 
 ## Configuration (TOML)

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -371,6 +371,28 @@ salt = "${file:/run/secrets/dumpling_hmac_key}"
 
 `[row_filters."table"]` can **`retain`** (OR: keep only if at least one predicate matches) and **`delete`** (drop if any predicate matches, evaluated after `retain`). The same predicate operators appear in `column_cases` `when.any` / `when.all`.
 
+### Cascade retain (related rows)
+
+Optional `[[row_filters."<parent>".cascade]]` entries keep child rows whose foreign key matches a **retained** parent primary key:
+
+```toml
+[row_filters."public.listing_order"]
+retain = [{ column = "status", op = "eq", value = "open" }]
+
+[[row_filters."public.listing_order".cascade]]
+child_table = "public.listing_orderitem"
+child_fk = "order_id"
+parent_pk = "id"
+```
+
+| Field | Meaning |
+|---|---|
+| `child_table` | Child table (`table` or `schema.table`), matched like other row_filters keys |
+| `child_fk` | Foreign-key column on the child |
+| `parent_pk` | Primary-key column on the parent (the table owning this cascade entry) |
+
+Parent table data must appear before child data in the dump. Cascade filtering is additive to any local retain/delete on the child. `NULL` child FKs are dropped. Full FK-graph discovery and multi-hop cascades are out of scope.
+
 | Operator | Description |
 |---|---|
 | `eq` / `neq` | String compare (case-insensitive if `case_insensitive = true`) |

--- a/docs/src/design-rationale.md
+++ b/docs/src/design-rationale.md
@@ -181,6 +181,7 @@ Optional `domain` + in-memory mapping cache (and optional uniqueness retries) ke
 ### Row filters and conditional cases
 
 - `row_filters` retain/delete whole rows before transforms.
+- Optional `[[row_filters."<parent>".cascade]]` links keep child rows only when their FK matches a retained parent PK (explicit, shallow, parent-before-child in the dump)—avoids orphan-trimmed graphs without live FK discovery.
 - `column_cases` apply first-match-wins strategies per row (including `keep` for allowlist exceptions, or cases-only scrub with keep-by-omission).
 - Predicate operators include positive and negating forms (`not_like` / `not_ilike` / `not_regex` / `not_iregex`); invalid Rust `regex` patterns fail closed at config load.
 - JSON path rules (dot or Django-style `__`) reach into `json` / `jsonb` text, including list-of-object shapes.

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,10 +1,10 @@
 use crate::settings::{
-    compile_regex_pattern, lookup_row_filters, parse_json_column_key, AnonymizerSpec, Predicate,
-    ResolvedConfig, When,
+    compile_regex_pattern, lookup_row_filters, parse_json_column_key, resolve_row_filter_table_key,
+    AnonymizerSpec, Predicate, ResolvedConfig, When,
 };
 use crate::transform::{apply_anonymizer, AnonymizerRegistry, Replacement};
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 
 /// Decide whether to keep a row based on configured filters.
@@ -42,6 +42,187 @@ pub fn should_keep_row(
         }
     }
     true
+}
+
+#[derive(Debug, Clone)]
+struct ChildCascadeLink {
+    parent_table_key: String,
+    parent_pk: String,
+    child_fk: String,
+}
+
+/// Streaming state for opt-in FK-aware parent→child retain cascading.
+///
+/// Built from `[row_filters.*.cascade]`. Parent tables must appear before their
+/// children in the dump so retained primary keys can be collected in one pass.
+#[derive(Debug, Default)]
+pub struct CascadeTracker {
+    by_child: HashMap<String, Vec<ChildCascadeLink>>,
+    parents_with_cascade: HashSet<String>,
+    parents_seen: HashSet<String>,
+    retained: HashMap<(String, String), HashSet<String>>,
+}
+
+impl CascadeTracker {
+    pub fn from_config(cfg: &ResolvedConfig) -> Self {
+        let mut by_child: HashMap<String, Vec<ChildCascadeLink>> = HashMap::new();
+        let mut parents_with_cascade = HashSet::new();
+        for (parent_key, set) in &cfg.row_filters {
+            if set.cascade.is_empty() {
+                continue;
+            }
+            parents_with_cascade.insert(parent_key.clone());
+            for rule in &set.cascade {
+                by_child
+                    .entry(rule.child_table.clone())
+                    .or_default()
+                    .push(ChildCascadeLink {
+                        parent_table_key: parent_key.clone(),
+                        parent_pk: rule.parent_pk.clone(),
+                        child_fk: rule.child_fk.clone(),
+                    });
+            }
+        }
+        Self {
+            by_child,
+            parents_with_cascade,
+            parents_seen: HashSet::new(),
+            retained: HashMap::new(),
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        !self.parents_with_cascade.is_empty()
+    }
+
+    /// Mark a cascade parent table as seen once its data section is processed.
+    pub fn note_table_data(&mut self, cfg: &ResolvedConfig, schema: Option<&str>, table: &str) {
+        if let Some(key) = resolve_row_filter_table_key(cfg, schema, table) {
+            if self.parents_with_cascade.contains(&key) {
+                self.parents_seen.insert(key);
+            }
+        }
+    }
+
+    /// After local retain/delete keep a row, enforce cascade membership for children
+    /// and record retained parent primary keys.
+    ///
+    /// Call [`note_table_data`] for the table before evaluating rows (including dropped
+    /// ones) so an empty retained-parent set is distinguishable from “parent not yet seen”.
+    pub fn after_local_keep(
+        &mut self,
+        cfg: &ResolvedConfig,
+        schema: Option<&str>,
+        table: &str,
+        columns: &[String],
+        cells: &[Option<&str>],
+    ) -> anyhow::Result<bool> {
+        if !self.is_active() {
+            return Ok(true);
+        }
+        if !self.child_fk_retained(schema, table, columns, cells)? {
+            return Ok(false);
+        }
+        self.record_retained_parent_pks(cfg, schema, table, columns, cells)?;
+        Ok(true)
+    }
+
+    fn child_links_for_table(&self, schema: Option<&str>, table: &str) -> &[ChildCascadeLink] {
+        if let Some(s) = schema {
+            let key = format!("{}.{}", s.to_lowercase(), table.to_lowercase());
+            if let Some(links) = self.by_child.get(&key) {
+                return links.as_slice();
+            }
+        }
+        self.by_child
+            .get(&table.to_lowercase())
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+    }
+
+    fn child_fk_retained(
+        &self,
+        schema: Option<&str>,
+        table: &str,
+        columns: &[String],
+        cells: &[Option<&str>],
+    ) -> anyhow::Result<bool> {
+        let links = self.child_links_for_table(schema, table);
+        if links.is_empty() {
+            return Ok(true);
+        }
+        let child_label = match schema {
+            Some(s) => format!("{}.{}", s, table),
+            None => table.to_string(),
+        };
+        for link in links {
+            if !self.parents_seen.contains(&link.parent_table_key) {
+                anyhow::bail!(
+                    "row_filters cascade: child table '{}' appears before parent '{}' in the dump; \
+                     parent data must appear first so retained primary keys can be collected",
+                    child_label,
+                    link.parent_table_key
+                );
+            }
+            let fk_idx = column_index(columns, &link.child_fk).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "row_filters cascade: child_fk '{}' not found in columns of table '{}'",
+                    link.child_fk,
+                    child_label
+                )
+            })?;
+            let fk_value = cells.get(fk_idx).copied().flatten();
+            let Some(fk_value) = fk_value else {
+                return Ok(false);
+            };
+            let key = (link.parent_table_key.clone(), link.parent_pk.clone());
+            let retained = self.retained.get(&key);
+            if !retained.is_some_and(|set| set.contains(fk_value)) {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    fn record_retained_parent_pks(
+        &mut self,
+        cfg: &ResolvedConfig,
+        schema: Option<&str>,
+        table: &str,
+        columns: &[String],
+        cells: &[Option<&str>],
+    ) -> anyhow::Result<()> {
+        let Some(parent_key) = resolve_row_filter_table_key(cfg, schema, table) else {
+            return Ok(());
+        };
+        if !self.parents_with_cascade.contains(&parent_key) {
+            return Ok(());
+        }
+        let Some(set) = cfg.row_filters.get(&parent_key) else {
+            return Ok(());
+        };
+        let parent_label = parent_key.as_str();
+        for rule in &set.cascade {
+            let pk_idx = column_index(columns, &rule.parent_pk).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "row_filters cascade: parent_pk '{}' not found in columns of table '{}'",
+                    rule.parent_pk,
+                    parent_label
+                )
+            })?;
+            if let Some(pk_value) = cells.get(pk_idx).copied().flatten() {
+                self.retained
+                    .entry((parent_key.clone(), rule.parent_pk.clone()))
+                    .or_default()
+                    .insert(pk_value.to_string());
+            }
+        }
+        Ok(())
+    }
+}
+
+fn column_index(columns: &[String], name: &str) -> Option<usize> {
+    columns.iter().position(|c| c.eq_ignore_ascii_case(name))
 }
 
 fn predicate_matches(pred: &Predicate, columns: &[String], cells: &[Option<&str>]) -> bool {
@@ -778,6 +959,7 @@ mod tests {
                             case_insensitive: None,
                             format: None,
                         }],
+                        cascade: vec![],
                     },
                 );
                 m
@@ -845,6 +1027,7 @@ mod tests {
                             },
                         ],
                         delete: vec![],
+                        cascade: vec![],
                     },
                 );
                 m
@@ -897,6 +1080,7 @@ mod tests {
                             case_insensitive: None,
                             format: None,
                         }],
+                        cascade: vec![],
                     },
                 );
                 m
@@ -944,6 +1128,7 @@ mod tests {
                             format: None,
                         }],
                         delete: vec![],
+                        cascade: vec![],
                     },
                 );
                 m
@@ -991,6 +1176,7 @@ mod tests {
                             format: None,
                         }],
                         delete: vec![],
+                        cascade: vec![],
                     },
                 );
                 m
@@ -1272,6 +1458,7 @@ mod tests {
                             },
                         ],
                         delete: vec![],
+                        cascade: vec![],
                     },
                 );
                 m
@@ -1340,6 +1527,7 @@ mod tests {
                             format: Some("date".to_string()),
                         }],
                         delete: vec![],
+                        cascade: vec![],
                     },
                 );
                 m
@@ -1387,6 +1575,7 @@ mod tests {
                             format: Some("datetime".to_string()),
                         }],
                         delete: vec![],
+                        cascade: vec![],
                     },
                 );
                 m
@@ -1430,5 +1619,94 @@ mod tests {
                 .to_string(),
             "2025-03-14"
         );
+    }
+
+    #[test]
+    fn cascade_tracker_retains_child_by_parent_pk() {
+        use crate::settings::CascadeRule;
+
+        let cfg = ResolvedConfig {
+            salt: None,
+            rules: HashMap::new(),
+            row_filters: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "public.orders".to_string(),
+                    RowFilterSet {
+                        retain: vec![Predicate {
+                            column: "keep".to_string(),
+                            op: "eq".to_string(),
+                            value: Some(serde_json::json!("yes")),
+                            values: None,
+                            case_insensitive: None,
+                            format: None,
+                        }],
+                        delete: vec![],
+                        cascade: vec![CascadeRule {
+                            child_table: "public.items".to_string(),
+                            child_fk: "order_id".to_string(),
+                            parent_pk: "id".to_string(),
+                        }],
+                    },
+                );
+                m
+            },
+            column_cases: HashMap::new(),
+            sensitive_columns: HashMap::new(),
+            output_scan: crate::settings::OutputScanConfig::default(),
+            pg_restore: crate::settings::PgRestoreConfig::default(),
+            keep_original: None,
+            source_path: None,
+        };
+        let mut tracker = CascadeTracker::from_config(&cfg);
+        let parent_cols = vec!["id".to_string(), "keep".to_string()];
+        tracker.note_table_data(&cfg, Some("public"), "orders");
+        assert!(tracker
+            .after_local_keep(
+                &cfg,
+                Some("public"),
+                "orders",
+                &parent_cols,
+                &[Some("1"), Some("yes")]
+            )
+            .unwrap());
+        assert!(tracker
+            .after_local_keep(
+                &cfg,
+                Some("public"),
+                "orders",
+                &parent_cols,
+                &[Some("2"), Some("yes")]
+            )
+            .unwrap());
+
+        let child_cols = vec!["id".to_string(), "order_id".to_string()];
+        assert!(tracker
+            .after_local_keep(
+                &cfg,
+                Some("public"),
+                "items",
+                &child_cols,
+                &[Some("10"), Some("1")]
+            )
+            .unwrap());
+        assert!(!tracker
+            .after_local_keep(
+                &cfg,
+                Some("public"),
+                "items",
+                &child_cols,
+                &[Some("11"), Some("99")]
+            )
+            .unwrap());
+        assert!(!tracker
+            .after_local_keep(
+                &cfg,
+                Some("public"),
+                "items",
+                &child_cols,
+                &[Some("12"), None]
+            )
+            .unwrap());
     }
 }

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -660,6 +660,7 @@ mod tests {
                     format: None,
                 }],
                 delete: vec![],
+                cascade: vec![],
             },
         );
 
@@ -686,6 +687,7 @@ mod tests {
                     format: None,
                 }],
                 delete: vec![],
+                cascade: vec![],
             },
         );
         let violations = lint_policy(&cfg);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2365,7 +2365,10 @@ parent_pk = "ID"
 "#,
         );
         let cfg = load_config(Some(&path), false).expect("cascade config should load");
-        let set = cfg.row_filters.get("public.listing_order").expect("filters");
+        let set = cfg
+            .row_filters
+            .get("public.listing_order")
+            .expect("filters");
         assert_eq!(set.cascade.len(), 1);
         assert_eq!(set.cascade[0].child_table, "public.listing_orderitem");
         assert_eq!(set.cascade[0].child_fk, "order_id");

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -572,6 +572,11 @@ fn resolve(raw: RawConfig, source_path: Option<PathBuf>) -> ResolvedConfig {
         for pred in set.retain.iter_mut().chain(set.delete.iter_mut()) {
             pred.op = pred.op.to_ascii_lowercase();
         }
+        for rule in set.cascade.iter_mut() {
+            rule.child_table = rule.child_table.trim().to_lowercase();
+            rule.child_fk = rule.child_fk.trim().to_lowercase();
+            rule.parent_pk = rule.parent_pk.trim().to_lowercase();
+        }
         normalized_filters.insert(table_key.to_lowercase(), set);
     }
     let mut normalized_cases: HashMap<String, HashMap<String, Vec<ColumnCase>>> = HashMap::new();
@@ -705,6 +710,12 @@ pub(crate) fn validate_raw_config(raw: &RawConfig) -> anyhow::Result<()> {
                 &format!("row_filters.\"{}\".delete[{}]", table_key, idx),
             )?;
         }
+        for (idx, rule) in set.cascade.iter().enumerate() {
+            validate_cascade_rule(
+                rule,
+                &format!("row_filters.\"{}\".cascade[{}]", table_key, idx),
+            )?;
+        }
     }
 
     validate_output_scan_config(&raw.output_scan)?;
@@ -718,6 +729,19 @@ fn validate_when_predicates(when: &When, path: &str) -> anyhow::Result<()> {
     }
     for (idx, pred) in when.all.iter().enumerate() {
         validate_predicate(pred, &format!("{}.all[{}]", path, idx))?;
+    }
+    Ok(())
+}
+
+fn validate_cascade_rule(rule: &CascadeRule, path: &str) -> anyhow::Result<()> {
+    if rule.child_table.trim().is_empty() {
+        anyhow::bail!("{}.child_table must be a non-empty table name", path);
+    }
+    if rule.child_fk.trim().is_empty() {
+        anyhow::bail!("{}.child_fk must be a non-empty column name", path);
+    }
+    if rule.parent_pk.trim().is_empty() {
+        anyhow::bail!("{}.parent_pk must be a non-empty column name", path);
     }
     Ok(())
 }
@@ -1334,7 +1358,7 @@ pub fn lookup_column_rule<'a>(
         .and_then(|cols| lookup_whole_column_rule_in_map(cols, &column_norm))
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct RowFilterSet {
     /// Keep a row if at least one predicate matches (when non-empty)
     /// Preferred name: retain. Back-compat alias: include_any.
@@ -1344,6 +1368,27 @@ pub struct RowFilterSet {
     /// Preferred name: delete. Back-compat alias: exclude_any.
     #[serde(default, alias = "exclude_any")]
     pub delete: Vec<Predicate>,
+    /// Opt-in parent→child retain cascading: keep child rows whose FK value
+    /// appears among retained parent primary keys. Parent table data must appear
+    /// before child data in the dump (streaming, single-pass).
+    #[serde(default)]
+    pub cascade: Vec<CascadeRule>,
+}
+
+/// Parent→child row retain link declared under a parent table's `[row_filters]`.
+///
+/// When the parent table is filtered (retain/delete), Dumpling records the
+/// `parent_pk` values of **kept** rows. Later rows of `child_table` are kept
+/// only when `child_fk` is in that retained set (in addition to any local
+/// retain/delete on the child).
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct CascadeRule {
+    /// Child table name (`table` or `schema.table`), matched like other row_filters keys.
+    pub child_table: String,
+    /// Foreign-key column on the child table.
+    pub child_fk: String,
+    /// Primary-key column on the parent table (the table owning this cascade entry).
+    pub parent_pk: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1395,6 +1440,26 @@ pub fn lookup_row_filters<'a>(
     }
     let key = table.to_lowercase();
     cfg.row_filters.get(&key)
+}
+
+/// Resolve the normalized `row_filters` map key for a dump table, if present.
+pub fn resolve_row_filter_table_key(
+    cfg: &ResolvedConfig,
+    schema: Option<&str>,
+    table: &str,
+) -> Option<String> {
+    if let Some(s) = schema {
+        let key = format!("{}.{}", s.to_lowercase(), table.to_lowercase());
+        if cfg.row_filters.contains_key(&key) {
+            return Some(key);
+        }
+    }
+    let key = table.to_lowercase();
+    if cfg.row_filters.contains_key(&key) {
+        Some(key)
+    } else {
+        None
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -2284,5 +2349,47 @@ retain = [{ column = "created", op = "gte", value = "2025-02-14", format = "epoc
         let msg = format!("{:#}", err);
         assert!(msg.contains("expected one of: datetime, date"));
         let _ = fs::remove_file(bad_format);
+    }
+
+    #[test]
+    fn cascade_rules_load_and_normalize() {
+        let path = write_temp_config(
+            r#"
+[row_filters."public.listing_order"]
+retain = [{ column = "status", op = "eq", value = "open" }]
+
+[[row_filters."public.listing_order".cascade]]
+child_table = "Public.Listing_OrderItem"
+child_fk = "Order_Id"
+parent_pk = "ID"
+"#,
+        );
+        let cfg = load_config(Some(&path), false).expect("cascade config should load");
+        let set = cfg.row_filters.get("public.listing_order").expect("filters");
+        assert_eq!(set.cascade.len(), 1);
+        assert_eq!(set.cascade[0].child_table, "public.listing_orderitem");
+        assert_eq!(set.cascade[0].child_fk, "order_id");
+        assert_eq!(set.cascade[0].parent_pk, "id");
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn empty_cascade_child_table_fails_validation() {
+        let path = write_temp_config(
+            r#"
+[row_filters."public.orders"]
+retain = [{ column = "id", op = "eq", value = "1" }]
+
+[[row_filters."public.orders".cascade]]
+child_table = "  "
+child_fk = "order_id"
+parent_pk = "id"
+"#,
+        );
+        let err = load_config(Some(&path), false).expect_err("empty child_table should fail");
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("row_filters.\"public.orders\".cascade[0]"));
+        assert!(msg.contains("child_table"));
+        let _ = fs::remove_file(path);
     }
 }

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1,4 +1,4 @@
-use crate::filter::{rewrite_json_paths_with_rules, should_keep_row, when_matches};
+use crate::filter::{rewrite_json_paths_with_rules, should_keep_row, when_matches, CascadeTracker};
 use crate::report::Reporter;
 use crate::settings::{
     is_explicit_sensitive_column, lookup_column_cases, lookup_column_rule,
@@ -36,6 +36,7 @@ pub struct SqlStreamProcessor {
     sensitive_columns_detected: HashSet<String>,
     sensitive_columns_covered: HashSet<String>,
     format: DumpFormat,
+    cascade: CascadeTracker,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -65,6 +66,7 @@ impl SqlStreamProcessor {
     ) -> Self {
         Self {
             anonymizers,
+            cascade: CascadeTracker::from_config(&config),
             config,
             column_length_limits: HashMap::new(),
             reporter: reporter.map(|r| r as *mut Reporter),
@@ -107,6 +109,22 @@ impl SqlStreamProcessor {
 
     pub fn anonymizers(&self) -> &AnonymizerRegistry {
         &self.anonymizers
+    }
+
+    /// Local row_filters plus optional FK cascade retain. Also marks cascade parents seen.
+    fn evaluate_row_keep(
+        &mut self,
+        schema: Option<&str>,
+        table: &str,
+        columns: &[String],
+        cells: &[Option<&str>],
+    ) -> anyhow::Result<bool> {
+        self.cascade.note_table_data(&self.config, schema, table);
+        if !should_keep_row(&self.config, schema, table, columns, cells) {
+            return Ok(false);
+        }
+        self.cascade
+            .after_local_keep(&self.config, schema, table, columns, cells)
     }
 
     pub fn process<R: BufRead, W: Write>(
@@ -184,6 +202,8 @@ impl SqlStreamProcessor {
                         let (schema, table) = parse_table_ident(cap.get(1).unwrap().as_str());
                         let columns = split_ident_list(cap.get(2).unwrap().as_str());
                         self.track_sensitive_coverage(schema.as_deref(), &table, &columns);
+                        self.cascade
+                            .note_table_data(&self.config, schema.as_deref(), &table);
                         // Emit the header intact
                         writer.write_all(line.as_bytes())?;
                         mode = Mode::InCopy {
@@ -232,13 +252,8 @@ impl SqlStreamProcessor {
                             .iter()
                             .map(|f| if *f == r"\N" { None } else { Some(*f) })
                             .collect();
-                        let keep = should_keep_row(
-                            &self.config,
-                            schema.as_deref(),
-                            table,
-                            columns,
-                            &unescaped,
-                        );
+                        let keep =
+                            self.evaluate_row_keep(schema.as_deref(), table, columns, &unescaped)?;
                         if !keep {
                             if let Some(rp) = self.reporter {
                                 unsafe {
@@ -365,6 +380,8 @@ impl SqlStreamProcessor {
         let (schema, table, rest_after_table) = parse_table_and_rest(after)?;
         let (columns, rest_after_cols) = parse_parenthesized_ident_list(rest_after_table)?;
         self.track_sensitive_coverage(schema.as_deref(), &table, &columns);
+        self.cascade
+            .note_table_data(&self.config, schema.as_deref(), &table);
         // Expect VALUES
         let idx_values = find_ignore_ascii_case(rest_after_cols, "VALUES")
             .ok_or_else(|| anyhow::anyhow!("INSERT missing VALUES"))?;
@@ -385,13 +402,7 @@ impl SqlStreamProcessor {
             // Row-level keep/drop
             let cell_values: Vec<Option<&str>> =
                 row.iter().map(|cell| cell.original.as_deref()).collect();
-            let keep = should_keep_row(
-                &self.config,
-                schema.as_deref(),
-                &table,
-                &columns,
-                &cell_values,
-            );
+            let keep = self.evaluate_row_keep(schema.as_deref(), &table, &columns, &cell_values)?;
             if !keep {
                 if let Some(rp) = self.reporter {
                     unsafe {
@@ -2736,6 +2747,7 @@ mod tests {
                     case_insensitive: None,
                     format: None,
                 }],
+                cascade: vec![],
             },
         );
         let cfg = ResolvedConfig {
@@ -2772,6 +2784,137 @@ COPY public.events (id, email, the_date) FROM stdin;
         assert!(!s.contains("(2, 'bob@example.com'"));
         assert!(s.contains("\n3\talice@myco.com\t")); // keep
         assert!(!s.contains("\n4\teve@example.com\t")); // drop
+    }
+
+    #[test]
+    fn cascade_retain_keeps_child_rows_for_retained_parents_insert_and_copy() {
+        use crate::settings::CascadeRule;
+
+        let mut row_filters = HashMap::new();
+        row_filters.insert(
+            "public.listing_order".to_string(),
+            RowFilterSet {
+                retain: vec![crate::settings::Predicate {
+                    column: "status".to_string(),
+                    op: "eq".to_string(),
+                    value: Some(serde_json::json!("open")),
+                    values: None,
+                    case_insensitive: None,
+                    format: None,
+                }],
+                delete: vec![],
+                cascade: vec![CascadeRule {
+                    child_table: "public.listing_orderitem".to_string(),
+                    child_fk: "order_id".to_string(),
+                    parent_pk: "id".to_string(),
+                }],
+            },
+        );
+        let cfg = ResolvedConfig {
+            salt: None,
+            rules: HashMap::new(),
+            row_filters,
+            column_cases: HashMap::new(),
+            sensitive_columns: HashMap::new(),
+            output_scan: crate::settings::OutputScanConfig::default(),
+            pg_restore: crate::settings::PgRestoreConfig::default(),
+            keep_original: None,
+            source_path: None,
+        };
+        let reg = AnonymizerRegistry::from_config(&cfg);
+        let mut proc = SqlStreamProcessor::new(reg, cfg, None, DumpFormat::Postgres);
+        let input = r#"
+INSERT INTO public.listing_order (id, status) VALUES
+  (1, 'open'),
+  (2, 'closed'),
+  (3, 'open');
+INSERT INTO public.listing_orderitem (id, order_id, sku) VALUES
+  (10, 1, 'A'),
+  (11, 2, 'B'),
+  (12, 3, 'C'),
+  (13, NULL, 'D');
+
+COPY public.listing_order (id, status) FROM stdin;
+4	open
+5	closed
+\.
+COPY public.listing_orderitem (id, order_id, sku) FROM stdin;
+20	4	E
+21	5	F
+22	1	G
+\.
+"#;
+        let mut reader = std::io::BufReader::new(input.as_bytes());
+        let mut out = Vec::new();
+        proc.process(&mut reader, &mut out).unwrap();
+        let s = String::from_utf8(out).unwrap();
+
+        // Parent retain
+        assert!(s.contains("(1, 'open')"));
+        assert!(s.contains("(3, 'open')"));
+        assert!(!s.contains("(2, 'closed')"));
+        assert!(s.contains("\n4\topen\n"));
+        assert!(!s.contains("\n5\tclosed\n"));
+
+        // Child cascade: only FKs to retained parents
+        assert!(s.contains("(10, 1, 'A')"));
+        assert!(s.contains("(12, 3, 'C')"));
+        assert!(!s.contains("(11, 2, 'B')"));
+        assert!(!s.contains("(13, NULL, 'D')") && !s.contains("(13, null, 'D')"));
+        assert!(s.contains("\n20\t4\tE\n"));
+        assert!(!s.contains("\n21\t5\tF\n"));
+        assert!(s.contains("\n22\t1\tG\n"));
+    }
+
+    #[test]
+    fn cascade_errors_when_child_appears_before_parent() {
+        use crate::settings::CascadeRule;
+
+        let mut row_filters = HashMap::new();
+        row_filters.insert(
+            "public.orders".to_string(),
+            RowFilterSet {
+                retain: vec![crate::settings::Predicate {
+                    column: "id".to_string(),
+                    op: "eq".to_string(),
+                    value: Some(serde_json::json!("1")),
+                    values: None,
+                    case_insensitive: None,
+                    format: None,
+                }],
+                delete: vec![],
+                cascade: vec![CascadeRule {
+                    child_table: "public.order_items".to_string(),
+                    child_fk: "order_id".to_string(),
+                    parent_pk: "id".to_string(),
+                }],
+            },
+        );
+        let cfg = ResolvedConfig {
+            salt: None,
+            rules: HashMap::new(),
+            row_filters,
+            column_cases: HashMap::new(),
+            sensitive_columns: HashMap::new(),
+            output_scan: crate::settings::OutputScanConfig::default(),
+            pg_restore: crate::settings::PgRestoreConfig::default(),
+            keep_original: None,
+            source_path: None,
+        };
+        let reg = AnonymizerRegistry::from_config(&cfg);
+        let mut proc = SqlStreamProcessor::new(reg, cfg, None, DumpFormat::Postgres);
+        let input = r#"
+INSERT INTO public.order_items (id, order_id) VALUES (1, 1);
+INSERT INTO public.orders (id) VALUES (1);
+"#;
+        let mut reader = std::io::BufReader::new(input.as_bytes());
+        let mut out = Vec::new();
+        let err = proc
+            .process(&mut reader, &mut out)
+            .expect_err("child before parent should fail");
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("appears before parent"));
+        assert!(msg.contains("public.orders"));
     }
 
     #[test]
@@ -3777,6 +3920,7 @@ INSERT INTO public.users (id, email, first_name, password, dob, notes) VALUES
                     case_insensitive: None,
                     format: None,
                 }],
+                cascade: vec![],
             },
         );
         let cfg = ResolvedConfig {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [#88](https://github.com/ababic/dumpling/issues/88): optional parent→child retain cascading for `row_filters`.

```toml
[row_filters."public.listing_order"]
retain = [{ column = "status", op = "eq", value = "open" }]

[[row_filters."public.listing_order".cascade]]
child_table = "public.listing_orderitem"
child_fk = "order_id"
parent_pk = "id"
```

While streaming a parent table, Dumpling records `parent_pk` values of kept rows. Child rows are kept only when `child_fk` is in that set (in addition to any local retain/delete). `NULL` FKs are dropped.

## Design notes

- Opt-in and shallow (explicit cascade links only)—no live FK discovery or full graph topo sort (per issue non-goals).
- Single-pass streaming: **parent data must appear before child data**; otherwise Dumpling fails with a clear error.
- Retained PK sets are held in memory for the run.

## Status

Rebased onto latest `main` (includes datetime/date predicate comparisons from [#87](https://github.com/ababic/dumpling/issues/87) / [#89](https://github.com/ababic/dumpling/pull/89)).

## Verification (post-rebase)

- `cargo test --all-targets --all-features` — 182 passed
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68667eae-d4e9-4afb-950f-7e9dd29b5150?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68667eae-d4e9-4afb-950f-7e9dd29b5150&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

