### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-14
+
 ### Added
 
-- **Datetime / date predicate comparisons**: `lt` / `lte` / `gt` / `gte` / `eq` / `neq` accept optional `format = "datetime"` (ISO-8601 / Postgres timestamp text as instants) or `format = "date"` (calendar dates). Thresholds are validated at config load; unparseable cell values fail closed ([#87](https://github.com/ababic/dumpling/issues/87)).
-- **`row_filters` cascade retain**: optional `[[row_filters."<parent>".cascade]]` entries keep child rows whose FK matches retained parent PKs (parent-before-child dump order required) ([#88](https://github.com/ababic/dumpling/issues/88)).
+- **Datetime / date predicate comparisons**: `lt` / `lte` / `gt` / `gte` / `eq` / `neq` accept optional `format = "datetime"` (ISO-8601 / Postgres timestamp text as instants) or `format = "date"` (calendar dates). Thresholds are validated at config load; unparseable cell values fail closed ([#87](https://github.com/ababic/dumpling/issues/87) / [#89](https://github.com/ababic/dumpling/pull/89)).
+- **`row_filters` cascade retain**: optional `[[row_filters."<parent>".cascade]]` entries keep child rows whose FK matches retained parent PKs (parent-before-child dump order required) ([#88](https://github.com/ababic/dumpling/issues/88) / [#90](https://github.com/ababic/dumpling/pull/90)).
 
 ## [0.8.0] - 2026-08-14
 
@@ -177,6 +179,7 @@ First **0.7.x** prerelease toward stable **0.7.0** (superseded by **0.7.0-beta**
 - Configurable output scan severities and per-category thresholds via `[output_scan]`.
 - JSON report section for output scan findings including category, count, threshold, severity, and sample locations.
 
+[0.9.0]: https://github.com/ababic/dumpling/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/ababic/dumpling/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/ababic/dumpling/compare/v0.6.0...v0.7.0
 [0.7.0-beta]: https://github.com/ababic/dumpling/compare/v0.7.0-alpha...v0.7.0-beta

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "dumpling"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dumpling"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 authors = ["Andy Babic"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "dumpling-cli"
-version = "0.8.0"
+version = "0.9.0"
 description = "Static anonymizer for plain SQL dumps (PostgreSQL, SQLite, SQL Server)."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Release preparation for **v0.9.0**.

## Changes

- Bump `Cargo.toml`, `Cargo.lock`, and `pyproject.toml` to `0.9.0`
- Promote Unreleased notes into a dated `0.9.0` CHANGELOG entry covering:
  - Datetime / date predicate comparisons (`format = "datetime"` / `format = "date"`)
  - Opt-in `row_filters` cascade retain (parent→child FK keep)

## Verification

- Local: `cargo fmt --check`, clippy (`-D warnings`), `cargo test --all-targets --all-features` (182 passed), `cargo build --release --locked` → `dumpling 0.9.0`
- GitHub CI on this PR: all checks green

## Post-merge

After merging, tag `main` and push to trigger **Release** and **Publish** workflows:

```bash
git tag -a v0.9.0 -m "Release v0.9.0"
git push origin v0.9.0
```

Optional: dispatch **Platform compatibility (matrix)** manually after the tag lands.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a694548-41a4-4183-81fe-aba59b378e84?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a694548-41a4-4183-81fe-aba59b378e84&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

